### PR TITLE
Replace SharpDX math with native .NET math

### DIFF
--- a/Core/Model/Model.TypeRegistration.cs
+++ b/Core/Model/Model.TypeRegistration.cs
@@ -447,8 +447,8 @@ public partial class SymbolData
                          int height = jsonToken["Height"].Value<int>();
                          return new Size2(width, height);
                      });
-        RegisterType(typeof(SharpDX.Vector4[]), "Vector4[]",
-                     () => new InputValue<SharpDX.Vector4[]>(Array.Empty<SharpDX.Vector4>()));
+        RegisterType(typeof(Vector4[]), "Vector4[]",
+                     () => new InputValue<Vector4[]>(Array.Empty<Vector4>()));
         RegisterType(typeof(Dict<float>), "Dict<float>",
                      () => new InputValue<Dict<float>>());
     }

--- a/Core/Operator/Animator.cs
+++ b/Core/Operator/Animator.cs
@@ -446,13 +446,13 @@ namespace T3.Core.Operator
             {
                 var curves = animator.GetCurvesForInput(inputSlot).ToArray();
                 double time = Playback.Current.TimeInBars;
-                SharpDX.Vector3 newValue = new SharpDX.Vector3(value.X, value.Y, value.Z);
+                Vector3 newValue = new Vector3(value.X, value.Y, value.Z);
                 for (int i = 0; i < 3; i++)
                 {
                     var key = curves[i].GetV(time);
                     if (key == null)
                         key = new VDefinition() { U = time };
-                    key.Value = newValue[i];
+                    key.Value = newValue.Axis(i);
                     curves[i].AddOrUpdateV(time, key);
                 }
             }

--- a/Core/Operator/EvaluationContext.cs
+++ b/Core/Operator/EvaluationContext.cs
@@ -1,11 +1,13 @@
 ﻿using System.Collections.Generic;
+using System.Numerics;
 using SharpDX;
 using SharpDX.Direct3D11;
 using T3.Core.Animation;
 using T3.Core.DataTypes;
 using T3.Core.Operator.Interfaces;
 using T3.Core.Rendering;
-using Vector3 = SharpDX.Vector3;
+using T3.Core.Utils;
+using Vector3 = System.Numerics.Vector3;
 using Vector4 = System.Numerics.Vector4;
 
 namespace T3.Core.Operator
@@ -39,23 +41,23 @@ namespace T3.Core.Operator
         {
             var fov = MathUtil.DegreesToRadians(45);
             var aspectRatio = (float)RequestedResolution.Width / RequestedResolution.Height;
-            CameraToClipSpace = Matrix.PerspectiveFovRH(fov, aspectRatio, 0.01f, 1000);
+            CameraToClipSpace = Math3DUtils.PerspectiveFovRH(fov, aspectRatio, 0.01f, 1000);
 
             Vector3 eye = new Vector3(camera.CameraPosition.X, camera.CameraPosition.Y, camera.CameraPosition.Z);
             Vector3 target = new Vector3(camera.CameraTarget.X, camera.CameraTarget.Y, camera.CameraTarget.Z);
-            Vector3 up = Vector3.Up;
-            WorldToCamera = Matrix.LookAtRH(eye, target, up);
+            Vector3 up = VectorT3.Up;
+            WorldToCamera = Math3DUtils.LookAtRH(eye, target, up);
 
-            ObjectToWorld = Matrix.Identity;
+            ObjectToWorld = Matrix4x4.Identity;
         }
 
         public void SetDefaultCamera()
         {
-            ObjectToWorld = Matrix.Identity;
-            WorldToCamera = Matrix.LookAtRH(new Vector3(0, 0, 2.4141f), Vector3.Zero, Vector3.Up);
+            ObjectToWorld = Matrix4x4.Identity;
+            WorldToCamera = Math3DUtils.LookAtRH(new Vector3(0, 0, 2.4141f), Vector3.Zero, VectorT3.Up);
             var fov = MathUtil.DegreesToRadians(45);
             float aspectRatio = (float)RequestedResolution.Width / RequestedResolution.Height;
-            CameraToClipSpace = Matrix.PerspectiveFovRH(fov, aspectRatio, 0.01f, 1000);
+            CameraToClipSpace = Math3DUtils.PerspectiveFovRH(fov, aspectRatio, 0.01f, 1000);
         }
 
         private static ICamera _defaultCamera = new ViewCamera();
@@ -83,9 +85,9 @@ namespace T3.Core.Operator
         
         public Size2 RequestedResolution { get; set; }
 
-        public Matrix CameraToClipSpace { get; set; } = Matrix.Identity;
-        public Matrix WorldToCamera { get; set; } = Matrix.Identity;
-        public Matrix ObjectToWorld { get; set; } = Matrix.Identity;
+        public Matrix4x4 CameraToClipSpace { get; set; } = Matrix4x4.Identity;
+        public Matrix4x4 WorldToCamera { get; set; } = Matrix4x4.Identity;
+        public Matrix4x4 ObjectToWorld { get; set; } = Matrix4x4.Identity;
         
         // Render settings
         public Buffer FogParameters { get; set; } = FogSettings.DefaultSettingsBuffer;

--- a/Core/Operator/Interfaces/ICamera.cs
+++ b/Core/Operator/Interfaces/ICamera.cs
@@ -1,5 +1,4 @@
-﻿using SharpDX;
-using Vector3 = System.Numerics.Vector3;
+﻿using System.Numerics;
 
 namespace T3.Core.Operator.Interfaces
 {
@@ -9,8 +8,8 @@ namespace T3.Core.Operator.Interfaces
         Vector3 CameraTarget { get; set; }
         float CameraRoll { get; set; }
         
-        SharpDX.Matrix WorldToCamera { get;  }
-        SharpDX.Matrix CameraToClipSpace { get;  }
+        Matrix4x4 WorldToCamera { get;  }
+        Matrix4x4 CameraToClipSpace { get;  }
     }
     
     // Mock view internal fallback camera (if no operator selected)
@@ -20,7 +19,7 @@ namespace T3.Core.Operator.Interfaces
         public Vector3 CameraPosition { get; set; } = new Vector3(0, 0, 2.416f);
         public Vector3 CameraTarget { get; set; }
         public float CameraRoll { get; set; }
-        public Matrix WorldToCamera { get; }
-        public Matrix CameraToClipSpace { get; }
+        public Matrix4x4 WorldToCamera { get; }
+        public Matrix4x4 CameraToClipSpace { get; }
     }
 }

--- a/Core/Rendering/MeshUtils.cs
+++ b/Core/Rendering/MeshUtils.cs
@@ -1,4 +1,5 @@
-﻿using SharpDX;
+﻿using System.Numerics;
+using T3.Core.Utils;
 
 namespace T3.Core.Rendering
 {

--- a/Core/Rendering/ObjMesh.cs
+++ b/Core/Rendering/ObjMesh.cs
@@ -5,6 +5,9 @@ using System.IO;
 using System.Linq;
 using SharpDX;
 using T3.Core.Logging;
+using Vector2 = System.Numerics.Vector2;
+using Vector3 = System.Numerics.Vector3;
+using Vector4 = System.Numerics.Vector4;
 
 // ReSharper disable RedundantNameQualifier
 
@@ -12,11 +15,11 @@ namespace T3.Core.Rendering
 {
     public class ObjMesh
     {
-        public readonly List<SharpDX.Vector3> Positions = new();
-        public readonly List<SharpDX.Vector4> Colors = new();
+        public readonly List<Vector3> Positions = new();
+        public readonly List<Vector4> Colors = new();
 
-        public readonly List<SharpDX.Vector3> Normals = new();
-        public readonly List<SharpDX.Vector2> TexCoords = new();
+        public readonly List<Vector3> Normals = new();
+        public readonly List<Vector2> TexCoords = new();
         public readonly List<Face> Faces = new();
         public readonly List<Line> Lines = new();
 
@@ -395,8 +398,8 @@ namespace T3.Core.Rendering
         }
 
         private List<Vertex> _distinctVertices;
-        public readonly List<SharpDX.Vector3> VertexTangents = new();
-        public readonly List<SharpDX.Vector3> VertexBinormals = new();
+        public readonly List<Vector3> VertexTangents = new();
+        public readonly List<Vector3> VertexBinormals = new();
         public List<int> SortedVertexIndices;
         private readonly Dictionary<long, int> _vertexIndicesByHash = new();
         #endregion

--- a/Core/Rendering/PrbDataTypes.cs
+++ b/Core/Rendering/PrbDataTypes.cs
@@ -8,6 +8,8 @@ using T3.Core.Operator;
 using T3.Core.Resource;
 using Buffer = SharpDX.Direct3D11.Buffer;
 using Vector4 = System.Numerics.Vector4;
+using Vector3 = System.Numerics.Vector3;
+using Vector2 = System.Numerics.Vector2;
 
 namespace T3.Core.Rendering
 {
@@ -15,19 +17,19 @@ namespace T3.Core.Rendering
     public struct PbrVertex
     {
         [FieldOffset(0)]
-        public SharpDX.Vector3 Position;
+        public Vector3 Position;
 
         [FieldOffset(3 * 4)]
-        public SharpDX.Vector3 Normal;
+        public Vector3 Normal;
 
         [FieldOffset(6 * 4)]
-        public SharpDX.Vector3 Tangent;
+        public Vector3 Tangent;
 
         [FieldOffset(9 * 4)]
-        public SharpDX.Vector3 Bitangent;
+        public Vector3 Bitangent;
 
         [FieldOffset(12 * 4)]
-        public SharpDX.Vector2 Texcoord;
+        public Vector2 Texcoord;
 
         [FieldOffset(14 * 4)]
         public float Selection; 

--- a/Core/Utils/GraphicsMathUtils.cs
+++ b/Core/Utils/GraphicsMathUtils.cs
@@ -1,0 +1,328 @@
+using System;
+using System.Numerics;
+
+namespace T3.Core.Utils;
+
+public static class Math3DUtils
+{
+    /// <summary>
+    /// System.Numerics implementation of SharpDX's LookAtRH method
+    /// </summary>
+    public static Matrix4x4 LookAtRH(Vector3 eye, Vector3 target, Vector3 up)
+    {
+        var zAxis = Vector3.Normalize(eye - target);
+        var xAxis = Vector3.Normalize(Vector3.Cross(up, zAxis));
+        var yAxis = Vector3.Cross(zAxis, xAxis);
+
+        return new Matrix4x4(
+                             xAxis.X, yAxis.X, zAxis.X, 0,
+                             xAxis.Y, yAxis.Y, zAxis.Y, 0,
+                             xAxis.Z, yAxis.Z, zAxis.Z, 0,
+                             -Vector3.Dot(xAxis, eye), -Vector3.Dot(yAxis, eye), -Vector3.Dot(zAxis, eye), 1
+                            );
+    }
+
+    private const float FovEpsilon = 0.0001f;
+    private const float MaxFov = MathF.PI - FovEpsilon;
+
+    public static Matrix4x4 PerspectiveFovRH(float fov, float aspect, float zNear, float zFar)
+    {
+        fov = MathF.Max(FovEpsilon, MathF.Min(fov, MaxFov));
+        aspect = MathF.Max(FovEpsilon, aspect);
+        zNear = MathF.Max(FovEpsilon, zNear);
+        zFar = MathF.Max(zNear + FovEpsilon, zFar);
+
+        var yScale = 1.0f / MathF.Tan(fov * 0.5f);
+        var xScale = yScale / aspect;
+        var differenceZNearZFar = zNear - zFar;
+
+        Matrix4x4 result;
+
+        result.M11 = xScale;
+        result.M12 = result.M13 = result.M14 = 0.0f;
+
+        result.M22 = yScale;
+        result.M21 = result.M23 = result.M24 = 0.0f;
+
+        result.M33 = zFar / differenceZNearZFar;
+        result.M31 = result.M32 = 0.0f;
+        result.M34 = -1.0f;
+
+        result.M41 = result.M42 = result.M44 = 0.0f;
+        result.M43 = zNear * zFar / differenceZNearZFar;
+
+        return result;
+    }
+
+    /// <summary>
+    /// Gets or sets the translation of the matrix; that is M41, M42, and M43.
+    /// </summary>
+    public static Vector3 GetTranslationVector(this Matrix4x4 matrix)
+    {
+        return new Vector3(matrix.M41, matrix.M42, matrix.M43);
+    }
+
+    public static void SetTranslationVector(this Matrix4x4 matrix, Vector3 translation)
+    {
+        matrix.M41 = translation.X;
+        matrix.M42 = translation.Y;
+        matrix.M43 = translation.Z;
+    }
+
+    public static Vector3 GetScaleVector(this Matrix4x4 matrix)
+    {
+        return new Vector3(matrix.M11, matrix.M22, matrix.M33);
+    }
+
+    public static void SetScaleVector(this Matrix4x4 matrix, Vector3 scale)
+    {
+        matrix.M11 = scale.X;
+        matrix.M22 = scale.Y;
+        matrix.M33 = scale.Z;
+    }
+
+    /// <summary>
+    /// Replicates SharpDX's TransformCoordinate function
+    /// </summary>
+    public static Vector3 TransformCoordinate(Vector3 coordinate, Matrix4x4 transform)
+    {
+        Vector4 result;
+        result.X = (coordinate.X * transform.M11 + coordinate.Y * transform.M21 + coordinate.Z * transform.M31) + transform.M41;
+        result.Y = (coordinate.X * transform.M12 + coordinate.Y * transform.M22 + coordinate.Z * transform.M32) + transform.M42;
+        result.Z = (coordinate.X * transform.M13 + coordinate.Y * transform.M23 + coordinate.Z * transform.M33) + transform.M43;
+        result.W = 1.0f / (coordinate.X * transform.M14 + coordinate.Y * transform.M24 + coordinate.Z * transform.M34 + transform.M44);
+
+        return new Vector3(result.X * result.W, result.Y * result.W, result.Z * result.W);
+    }
+
+    public static Matrix4x4 CreateTransformationMatrix(in Vector3 scalingCenter,
+                                                       in Quaternion scalingRotation,
+                                                       in Vector3 scaling,
+                                                       in Vector3 rotationCenter,
+                                                       in Quaternion rotation,
+                                                       in Vector3 translation)
+    {
+        // Create rotation matrices from quaternions
+        Matrix4x4 scalingRotationMatrix = Matrix4x4.CreateFromQuaternion(scalingRotation);
+        Matrix4x4 rotationMatrix = Matrix4x4.CreateFromQuaternion(rotation);
+
+        // Create inverse rotation matrix from the conjugate of the quaternion
+        Matrix4x4 inverseScalingRotationMatrix = Matrix4x4.CreateFromQuaternion(Quaternion.Conjugate(scalingRotation));
+
+        // Create translation matrices for the rotation and scaling centers
+        Matrix4x4 scalingCenterTranslation = Matrix4x4.CreateTranslation(-scalingCenter);
+        Matrix4x4 rotationCenterTranslation = Matrix4x4.CreateTranslation(-rotationCenter);
+
+        // Create the inverse translations
+        Matrix4x4 inverseScalingCenterTranslation = Matrix4x4.CreateTranslation(scalingCenter);
+        Matrix4x4 inverseRotationCenterTranslation = Matrix4x4.CreateTranslation(rotationCenter);
+
+        // Create the scaling matrix
+        Matrix4x4 scalingMatrix = Matrix4x4.CreateScale(scaling);
+
+        // Create the final translation matrix
+        Matrix4x4 finalTranslationMatrix = Matrix4x4.CreateTranslation(translation);
+
+        // Combine the matrices to form the transformation matrix
+        Matrix4x4 transformationMatrix =
+            scalingCenterTranslation *
+            inverseScalingRotationMatrix *
+            scalingMatrix *
+            scalingRotationMatrix *
+            inverseScalingCenterTranslation *
+            rotationCenterTranslation *
+            rotationMatrix *
+            inverseRotationCenterTranslation *
+            finalTranslationMatrix;
+
+        return transformationMatrix;
+    }
+}
+
+public static class VectorT3
+{
+    public static readonly Vector3 Up = new(0, 1, 0);
+    public static readonly Vector3 Down = new(0, -1, 0);
+    public static readonly Vector3 Right = new(1, 0, 0);
+    public static readonly Vector3 Left = new(-1, 0, 0);
+    
+    /// <summary>
+    /// Represents a vector pointing forwards (0, 0, -1) in a right-handed coordinate system.
+    /// </summary>
+    public static readonly Vector3 Forward = new(0, 0, -1); 
+    public static readonly Vector3 ForwardRH = new(0, 0, -1);
+    public static readonly Vector3 ForwardLH = new(0, 0, 1);
+    
+    /// <summary>
+    /// Represents a vector pointing backwards (0, 0, 1) in a right-handed coordinate system.
+    /// </summary>
+    public static readonly Vector3 Backward = new(0, 0, 1);
+    public static readonly Vector3 BackwardRH = new(0, 0, 1);
+    public static readonly Vector3 BackwardLH = new(0, 0, -1);
+    
+    
+    public static void Normalize(this ref Vector3 vec) => Vector3.Normalize(vec);
+    public static Vector4 ToVector4(this Vector3 vec, float w) => new(vec.X, vec.Y, vec.Z, w);
+    public static float Axis(this Vector3 vec, int axis) => axis switch
+    {
+        0 => vec.X,
+        1 => vec.Y,
+        2 => vec.Z,
+        _ => throw new ArgumentOutOfRangeException(nameof(axis))
+    };
+}
+
+public static class VectorT4
+{
+    
+}
+
+public struct Ray
+{
+    public Vector3 Origin { get; set; }
+    public Vector3 Direction { get; set; }
+
+    /// <summary>
+    /// An alias for <see cref="Origin"/> for those familiar with SharpDX
+    /// </summary>
+    public Vector3 Position
+    {
+        get => Origin;
+        set => Origin = value;
+    }
+
+    public Ray(Vector3 origin, Vector3 direction)
+    {
+        Origin = origin;
+        Direction = direction;
+    }
+
+    public bool Intersects(in Plane plane, out float distance)
+    {
+        // Get the dot product of the direction vector of the ray and the normal of the plane
+        float denominator = Vector3.Dot(Direction, plane.Normal);
+
+        // If the dot product is close to zero, the ray is parallel to the plane (no intersection)
+        if (Math.Abs(denominator) < float.Epsilon)
+        {
+            distance = 0;
+            return false;
+        }
+
+        // Calculate the distance from the ray origin to the plane
+        float nominator = Vector3.Dot(Origin - plane.Normal * plane.D, -plane.Normal);
+        distance = nominator / denominator;
+
+        // If the distance is less than zero, the plane is behind the ray origin (we consider this as no intersection)
+        if (distance < 0)
+        {
+            distance = 0;
+            return false;
+        }
+
+        return true;
+    }
+}
+
+public static class PlaneExtensions
+{
+    public static bool Intersects(this Plane plane, in Ray ray, out Vector3 point)
+    {
+        float denominator = Vector3.Dot(plane.Normal, ray.Direction);
+
+        if (Math.Abs(denominator) < float.Epsilon)
+        {
+            point = default;
+            return false;
+        }
+
+        float t = (plane.D - Vector3.Dot(plane.Normal, ray.Origin)) / denominator;
+
+        if (t < 0)
+        {
+            point = default;
+            return false;
+        }
+
+        point = ray.Origin + t * ray.Direction;
+        return true;
+    }
+
+    /// <summary>
+    /// Creates a plane from a point that lies on the plane and the normal vector.
+    /// Implementation basically copied from SharpDX.
+    /// </summary>
+    /// <param name="point">Any point that lies along the plane.</param>
+    /// <param name="normal">The normal vector to the plane.</param>
+    public static Plane PlaneFromPointAndNormal(Vector3 point, Vector3 normal)
+    {
+        var d = -Vector3.Dot(normal, point);
+        return new Plane(normal, d);
+    }
+}
+
+public static class MatrixExtensions
+{
+    public static bool Invert(this ref Matrix4x4 mat)
+    {
+        return Matrix4x4.Invert(mat, out mat);
+    }
+
+    public static Vector4 Row1(this Matrix4x4 mat)
+    {
+        return new Vector4(mat.M11, mat.M12, mat.M13, mat.M14);
+    }
+
+    public static Vector4 Row2(this Matrix4x4 mat)
+    {
+        return new Vector4(mat.M21, mat.M22, mat.M23, mat.M24);
+    }
+
+    public static Vector4 Row3(this Matrix4x4 mat)
+    {
+        return new Vector4(mat.M31, mat.M32, mat.M33, mat.M34);
+    }
+
+    public static Vector4 Row4(this Matrix4x4 mat)
+    {
+        return new Vector4(mat.M41, mat.M42, mat.M43, mat.M44);
+    }
+
+    /// <summary>
+    /// Transposes the specified matrix. -Copied from SharpDX
+    /// For use with row-major matrices (like DirectX matrices)
+    /// </summary>
+    /// <param name="mat"></param>
+    public static void Transpose(ref this Matrix4x4 mat)
+    {
+        Transpose(ref mat, out mat);
+    }
+
+    /// <summary>
+    /// Calculates the transpose of the specified matrix. -Copied from SharpDX
+    /// </summary>
+    /// <param name="value">The matrix whose transpose is to be calculated.</param>
+    /// <param name="result">When the method completes, contains the transpose of the specified matrix.</param>
+    public static void Transpose(ref Matrix4x4 value, out Matrix4x4 result)
+    {
+        Matrix4x4 temp = new Matrix4x4();
+        temp.M11 = value.M11;
+        temp.M12 = value.M21;
+        temp.M13 = value.M31;
+        temp.M14 = value.M41;
+        temp.M21 = value.M12;
+        temp.M22 = value.M22;
+        temp.M23 = value.M32;
+        temp.M24 = value.M42;
+        temp.M31 = value.M13;
+        temp.M32 = value.M23;
+        temp.M33 = value.M33;
+        temp.M34 = value.M43;
+        temp.M41 = value.M14;
+        temp.M42 = value.M24;
+        temp.M43 = value.M34;
+        temp.M44 = value.M44;
+
+        result = temp;
+    }
+}

--- a/Core/Utils/MathUtils.cs
+++ b/Core/Utils/MathUtils.cs
@@ -336,6 +336,12 @@ namespace T3.Core.Utils
             return new SharpDX.Vector3(source.X, source.Y, source.Z);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static SharpDX.Vector2 ToSharpDxVector2(this Vector2 source)
+        {
+            return new SharpDX.Vector2(source.X, source.Y);
+        }
+
         /// <summary>
         /// Return true if a boolean changed from false to true
         /// </summary>

--- a/Editor/Gui/Interaction/Camera/SpaceMouse.cs
+++ b/Editor/Gui/Interaction/Camera/SpaceMouse.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Numerics;
 using System.Windows.Forms;
 using SharpDX;
 using T3.Core.Utils;
 using T3.Editor.App;
 using T3.Editor.Gui.UiHelpers;
+using Vector3 = System.Numerics.Vector3;
 
 namespace T3.Editor.Gui.Interaction.Camera
 {
@@ -53,7 +55,7 @@ namespace T3.Editor.Gui.Interaction.Camera
             _rotationSum = new Vector3(0, 0, 0);
 
             
-            var viewDir = intendedSetup.Target.ToSharpDxVector3() - intendedSetup.Position.ToSharpDxVector3();
+            var viewDir = intendedSetup.Target - intendedSetup.Position;
             
             
             
@@ -84,16 +86,16 @@ namespace T3.Editor.Gui.Interaction.Camera
 
             var moveDir = direction.X * sideDir - direction.Y * viewDir - direction.Z * upDir;
 
-            var rotAroundX = Matrix.RotationAxis(sideDir, -_dampedRotation.X / 8000.0f);
-            var rotAroundY = Matrix.RotationAxis(upDir, -_dampedRotation.Y / 8000.0f);
-            var rot = Matrix.Multiply(rotAroundX, rotAroundY);
+            var rotAroundX = Matrix4x4.CreateFromAxisAngle(sideDir, -_dampedRotation.X / 8000.0f);
+            var rotAroundY = Matrix4x4.CreateFromAxisAngle(upDir, -_dampedRotation.Y / 8000.0f);
+            var rot = Matrix4x4.Multiply(rotAroundX, rotAroundY);
             var newViewDir = Vector3.Transform(viewDir, rot);
             newViewDir.Normalize();
 
             var oldPosition = intendedSetup.Position;
-            intendedSetup.Position += moveDir.ToNumerics();
-            
-            intendedSetup.Target = oldPosition + (moveDir + newViewDir.ToVector3() * viewDirLength).ToNumerics();
+            intendedSetup.Position += moveDir;
+
+            intendedSetup.Target = oldPosition + (moveDir + newViewDir * viewDirLength);
             //Log.Debug($"space mouse move: {moveDir}  eventCount:{_eventCount}");
 
         }

--- a/Editor/UiModel/UiModel.TypeRegistration.cs
+++ b/Editor/UiModel/UiModel.TypeRegistration.cs
@@ -17,6 +17,7 @@ using T3.Editor.Gui.InputUi.VectorInputs;
 using T3.Editor.Gui.OutputUi;
 using Buffer = SharpDX.Direct3D11.Buffer;
 using Point = T3.Core.DataTypes.Point;
+using Vector4 = System.Numerics.Vector4;
 
 namespace T3.Editor.UiModel;
 
@@ -203,8 +204,8 @@ public partial class UiSymbolData
                        () => new ValueOutputUi<RawViewportF>());
         RegisterUiType(typeof(SharpDX.Mathematics.Interop.RawRectangle), new ShaderUiProperties(), () => new FallbackInputUi<RawRectangle>(),
                        () => new ValueOutputUi<RawRectangle>());
-        RegisterUiType(typeof(SharpDX.Vector4[]), new PointListUiProperties(), () => new FallbackInputUi<SharpDX.Vector4[]>(),
-                       () => new ValueOutputUi<SharpDX.Vector4[]>());
+        RegisterUiType(typeof(Vector4[]), new PointListUiProperties(), () => new FallbackInputUi<Vector4[]>(),
+                       () => new ValueOutputUi<Vector4[]>());
         RegisterUiType(typeof(Dict<float>), new ValueUiProperties(),
                        () => new FloatDictInputUi(), () => new FloatDictOutputUi());
     }

--- a/Operators/Types/lib/3d/_/ApplyCamMatrices.cs
+++ b/Operators/Types/lib/3d/_/ApplyCamMatrices.cs
@@ -1,6 +1,6 @@
 using System;
+using System.Numerics;
 using ManagedBass;
-using SharpDX;
 using T3.Core;
 using T3.Core.DataTypes;
 using T3.Core.Logging;
@@ -35,18 +35,18 @@ namespace T3.Operators.Types.Id_3dae14a8_3d0b_432f_b951_bdd7afd7e5f8
 
             var previousWorldTobject = context.ObjectToWorld;
             
-            context.ObjectToWorld = Matrix.Multiply(worldToCam, context.ObjectToWorld);
+            context.ObjectToWorld = Matrix4x4.Multiply(worldToCam, context.ObjectToWorld);
             
             Command.GetValue(context);
             context.ObjectToWorld = previousWorldTobject;
         }
 
-        private static Matrix MatrixFromRows(Vector4[] rows)
+        private static Matrix4x4 MatrixFromRows(Vector4[] rows)
         {
             if(rows == null || rows.Length != 4)
-                return Matrix.Identity;
+                return Matrix4x4.Identity;
             
-            return new Matrix(
+            return new Matrix4x4(
                               rows[0].X, rows[0].Y, rows[0].Z, rows[0].W,
                        rows[1].X, rows[1].Y, rows[1].Z, rows[1].W,
                        rows[2].X, rows[2].Y, rows[2].Z, rows[2].W,
@@ -57,10 +57,10 @@ namespace T3.Operators.Types.Id_3dae14a8_3d0b_432f_b951_bdd7afd7e5f8
         public readonly InputSlot<Command> Command = new();
 
         [Input(Guid = "86FA7A95-C6DF-4BB8-A447-E92882A99037")]
-        public readonly InputSlot<SharpDX.Vector4[]> WorldToCamRows = new();
+        public readonly InputSlot<Vector4[]> WorldToCamRows = new();
         
         [Input(Guid = "6DD0EC68-5B73-4C19-8043-1CA91BBD0AF3")]
-        public readonly InputSlot<SharpDX.Vector4[]> CamToClipSpaceRows = new();
+        public readonly InputSlot<Vector4[]> CamToClipSpaceRows = new();
         
     }
 }

--- a/Operators/Types/lib/3d/_/ApplyTransformMatrix.cs
+++ b/Operators/Types/lib/3d/_/ApplyTransformMatrix.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Numerics;
 using ManagedBass;
 using SharpDX;
 using T3.Core;
@@ -9,6 +10,8 @@ using T3.Core.Operator.Attributes;
 using T3.Core.Operator.Interfaces;
 using T3.Core.Operator.Slots;
 using T3.Core.Resource;
+using T3.Core.Utils;
+using Vector4 = System.Numerics.Vector4;
 
 namespace T3.Operators.Types.Id_195afff5_13f6_4c5d_af49_655a4f92c2f8
 {
@@ -28,7 +31,7 @@ namespace T3.Operators.Types.Id_195afff5_13f6_4c5d_af49_655a4f92c2f8
             matrix.Transpose();
             
             var previousObjectToWorld = context.ObjectToWorld;
-            context.ObjectToWorld = Matrix.Multiply(matrix, context.ObjectToWorld);
+            context.ObjectToWorld = Matrix4x4.Multiply(matrix, context.ObjectToWorld);
             Command.GetValue(context);
             context.ObjectToWorld = previousObjectToWorld;
 
@@ -41,12 +44,12 @@ namespace T3.Operators.Types.Id_195afff5_13f6_4c5d_af49_655a4f92c2f8
             // context.ObjectToWorld = previousWorldTobject;
         }
 
-        private static Matrix MatrixFromRows(Vector4[] rows)
+        private static Matrix4x4 MatrixFromRows(Vector4[] rows)
         {
             if(rows == null || rows.Length != 4)
-                return Matrix.Identity;
+                return Matrix4x4.Identity;
             
-            return new Matrix(
+            return new Matrix4x4(
                               rows[0].X, rows[0].Y, rows[0].Z, rows[0].W,
                        rows[1].X, rows[1].Y, rows[1].Z, rows[1].W,
                        rows[2].X, rows[2].Y, rows[2].Z, rows[2].W,
@@ -57,7 +60,7 @@ namespace T3.Operators.Types.Id_195afff5_13f6_4c5d_af49_655a4f92c2f8
         public readonly InputSlot<Command> Command = new();
 
         [Input(Guid = "c3b1ba6c-4306-4ae4-9429-d1f2461e2e8c")]
-        public readonly InputSlot<SharpDX.Vector4[]> TransformRows = new();
+        public readonly InputSlot<Vector4[]> TransformRows = new();
         
     }
 }

--- a/Operators/Types/lib/3d/_/PickSDXVector4.cs
+++ b/Operators/Types/lib/3d/_/PickSDXVector4.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Numerics;
 using T3.Core.Operator;
 using T3.Core.Operator.Attributes;
 using T3.Core.Operator.Slots;
@@ -40,12 +41,12 @@ namespace T3.Operators.Types.Id_a83f2e4f_cb4d_4a6f_9f7a_2ea7fdfab54b
             if (index < 0)
                 index = -index;
 
-            SharpDX.Vector4 v= list[index % list.Length];
+            Vector4 v = list[index % list.Length];
 
-            Value1.Value = v[0];
-            Value2.Value = v[1];
-            Value3.Value = v[2];
-            Value4.Value = v[3];
+            Value1.Value = v.X;
+            Value2.Value = v.Y;
+            Value3.Value = v.Z;
+            Value4.Value = v.W;
 
             Value1.DirtyFlag.Clear();
             Value2.DirtyFlag.Clear();
@@ -54,7 +55,7 @@ namespace T3.Operators.Types.Id_a83f2e4f_cb4d_4a6f_9f7a_2ea7fdfab54b
         }
 
         [Input(Guid = "0f9eebb0-6f13-4751-abac-15a467ad56c2")]
-        public readonly InputSlot<SharpDX.Vector4[]> Input = new InputSlot<SharpDX.Vector4[]>();
+        public readonly InputSlot<Vector4[]> Input = new InputSlot<Vector4[]>();
 
         [Input(Guid = "dbc92e88-cae2-44a8-b291-1a6168624244")]
         public readonly InputSlot<int> Index = new InputSlot<int>(0);

--- a/Operators/Types/lib/3d/_/TransformMatrix.cs
+++ b/Operators/Types/lib/3d/_/TransformMatrix.cs
@@ -1,5 +1,5 @@
 using System;
-using SharpDX;
+using System.Numerics;
 using T3.Core;
 using T3.Core.Operator;
 using T3.Core.Operator.Attributes;
@@ -12,11 +12,11 @@ namespace T3.Operators.Types.Id_17324ce1_8920_4653_ac67_c211ad507a81
     public class TransformMatrix : Instance<TransformMatrix>
     {
         [Output(Guid = "751E97DE-C418-48C7-823E-D4660073A559")]
-        public readonly Slot<SharpDX.Vector4[]> Result = new Slot<SharpDX.Vector4[]>();
+        public readonly Slot<Vector4[]> Result = new Slot<Vector4[]>();
         
 
         [Output(Guid = "ECA8121B-2A7F-4ECC-9143-556DCF78BA33")]
-        public readonly Slot<SharpDX.Vector4[]> ResultInverted = new Slot<SharpDX.Vector4[]>();
+        public readonly Slot<Vector4[]> ResultInverted = new Slot<Vector4[]>();
         
         public TransformMatrix()
         {
@@ -28,27 +28,27 @@ namespace T3.Operators.Types.Id_17324ce1_8920_4653_ac67_c211ad507a81
         {
             var s = Scale.GetValue(context) * UniformScale.GetValue(context);
             var r = Rotation.GetValue(context);
-            float yaw = MathUtil.DegreesToRadians(r.Y);
-            float pitch = MathUtil.DegreesToRadians(r.X);
-            float roll = MathUtil.DegreesToRadians(r.Z);
-            var pivot = Pivot.GetValue(context).ToSharpDxVector3();
+            float yaw = MathUtils.ToRad * r.Y;
+            float pitch = MathUtils.ToRad * r.X;
+            float roll = MathUtils.ToRad * r.Z;
+            var pivot = Pivot.GetValue(context);
             var t = Translation.GetValue(context);
-            var objectToParentObject = Matrix.Transformation(scalingCenter: pivot, 
+            var objectToParentObject = Math3DUtils.CreateTransformationMatrix(scalingCenter: pivot, 
                                                              scalingRotation: Quaternion.Identity, 
                                                              scaling: new Vector3(s.X, s.Y, s.Z), 
                                                              rotationCenter: pivot,
-                                                             rotation: Quaternion.RotationYawPitchRoll(yaw, pitch, roll), 
+                                                             rotation: Quaternion.CreateFromYawPitchRoll(yaw, pitch, roll), 
                                                              translation: new Vector3(t.X, t.Y, t.Z));
 
             var shearing = Shear.GetValue(context);
             
               
             
-            Matrix m = Matrix.Identity;
+            Matrix4x4 m = Matrix4x4.Identity;
             m.M12=shearing.Y; 
             m.M21=shearing.X; 
             m.M13=shearing.Z;             
-            objectToParentObject = Matrix.Multiply(objectToParentObject,m);
+            objectToParentObject = Matrix4x4.Multiply(objectToParentObject,m);
             
             // transpose all as mem layout in hlsl constant buffer is row based
             objectToParentObject.Transpose();
@@ -58,24 +58,24 @@ namespace T3.Operators.Types.Id_17324ce1_8920_4653_ac67_c211ad507a81
                 objectToParentObject.Invert(); 
             }
             
-            _matrix[0] = objectToParentObject.Row1;
-            _matrix[1] = objectToParentObject.Row2;
-            _matrix[2] = objectToParentObject.Row3;
-            _matrix[3] = objectToParentObject.Row4;
+            _matrix[0] = objectToParentObject.Row1();
+            _matrix[1] = objectToParentObject.Row2();
+            _matrix[2] = objectToParentObject.Row3();
+            _matrix[3] = objectToParentObject.Row4();
             Result.Value = _matrix;
 
-            var invertedMatrix = Matrix.Invert(objectToParentObject);
+            Matrix4x4.Invert(objectToParentObject, out var invertedMatrix);
             
-            _invertedMatrix[0] = invertedMatrix.Row1;
-            _invertedMatrix[1] = invertedMatrix.Row2;
-            _invertedMatrix[2] = invertedMatrix.Row3;
-            _invertedMatrix[3] = invertedMatrix.Row4;
+            _invertedMatrix[0] = invertedMatrix.Row1();
+            _invertedMatrix[1] = invertedMatrix.Row2();
+            _invertedMatrix[2] = invertedMatrix.Row3();
+            _invertedMatrix[3] = invertedMatrix.Row4();
             ResultInverted.Value = _invertedMatrix;
             
         }
 
-        private SharpDX.Vector4[] _matrix = new SharpDX.Vector4[4];
-        private SharpDX.Vector4[] _invertedMatrix = new SharpDX.Vector4[4];
+        private Vector4[] _matrix = new Vector4[4];
+        private Vector4[] _invertedMatrix = new Vector4[4];
         
         
         

--- a/Operators/Types/lib/3d/_/_LenseFlareHoopPosition.cs
+++ b/Operators/Types/lib/3d/_/_LenseFlareHoopPosition.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Numerics;
 using SharpDX;
 using T3.Core;
 using T3.Core.Logging;
@@ -33,7 +34,7 @@ namespace T3.Operators.Types.Id_1cfe41c7_972e_4243_9ae4_a510ac038191
 
         private void Update(EvaluationContext context)
         {
-            var worldToClipSpace = Matrix.Multiply(context.WorldToCamera, context.CameraToClipSpace);
+            var worldToClipSpace = Matrix4x4.Multiply(context.WorldToCamera, context.CameraToClipSpace);
             var color = Color.GetValue(context);
             var randomizeColor = RandomizeColor.GetValue(context);
             var size = Size.GetValue(context);
@@ -53,9 +54,9 @@ namespace T3.Operators.Types.Id_1cfe41c7_972e_4243_9ae4_a510ac038191
             var fxZoneMode = (ZoneFxModes)FxZoneMode.GetValue(context);
 
             var pointLight = context.PointLights.GetPointLight(referencedLightIndex);
-            var lightPosDx = pointLight.Position.ToSharpDxVector4(1);
+            var lightPos = pointLight.Position.ToVector4(1);
 
-            var posInViewDx = SharpDX.Vector4.Transform(lightPosDx, worldToClipSpace);
+            var posInViewDx = Vector4.Transform(lightPos, worldToClipSpace);
             posInViewDx /= posInViewDx.W;
 
             

--- a/Operators/Types/lib/3d/_/_LenseFlareSprites.cs
+++ b/Operators/Types/lib/3d/_/_LenseFlareSprites.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 using System.Runtime.InteropServices;
 using SharpDX;
 using T3.Core;
@@ -28,7 +29,7 @@ namespace T3.Operators.Types.Id_947ad81e_47da_46c3_9b1d_8e578174d876
 
         private void Update(EvaluationContext context)
         {
-            var worldToClipSpace = Matrix.Multiply(context.WorldToCamera, context.CameraToClipSpace);
+            var worldToClipSpace = Matrix4x4.Multiply(context.WorldToCamera, context.CameraToClipSpace);
             //Matrix worldToView = context.WorldToCamera * context.CameraProjection;
             //var worldToClipSpace = context.WorldToCamera
             //var viewToWorld = Matrix.Invert(worldToClipSpace);
@@ -85,9 +86,9 @@ namespace T3.Operators.Types.Id_947ad81e_47da_46c3_9b1d_8e578174d876
                 for (int lightIndex = startLightIndex; lightIndex < endLightIndex; lightIndex++)
                 {
                     var pointLight = context.PointLights.GetPointLight(lightIndex);
-                    var lightPosDx = pointLight.Position.ToSharpDxVector4(1);
+                    var lightPosDx = pointLight.Position.ToVector4(1);
 
-                    var posInViewDx = SharpDX.Vector4.Transform(lightPosDx, worldToClipSpace);
+                    var posInViewDx = Vector4.Transform(lightPosDx, worldToClipSpace);
                     posInViewDx /= posInViewDx.W;
 
                     // Ignore light sources behind

--- a/Operators/Types/lib/3d/_/_ProcessLayer2d.cs
+++ b/Operators/Types/lib/3d/_/_ProcessLayer2d.cs
@@ -1,5 +1,5 @@
 using System;
-using SharpDX;
+using System.Numerics;
 using SharpDX.Direct3D11;
 using T3.Core.Logging;
 using T3.Core.Operator;
@@ -14,7 +14,7 @@ namespace T3.Operators.Types.Id_d8699da1_13aa_42f7_816a_88abb1d0ba06
     public class _ProcessLayer2d : Instance<_ProcessLayer2d>
     {
         [Output(Guid = "D81A2DB8-D72D-48B1-9201-0EE87822097E", DirtyFlagTrigger = DirtyFlagTrigger.Animated)]
-        public readonly Slot<SharpDX.Vector4[]> Result = new Slot<SharpDX.Vector4[]>();
+        public readonly Slot<Vector4[]> Result = new Slot<Vector4[]>();
         
         public _ProcessLayer2d()
         {
@@ -25,12 +25,12 @@ namespace T3.Operators.Types.Id_d8699da1_13aa_42f7_816a_88abb1d0ba06
         private void Update(EvaluationContext context)
         {
             var imageTexture = ImageTexture.GetValue(context);
-            var imageSize = new Size2(1,1);
+            var imageSize = new SharpDX.Size2(1,1);
             if (imageTexture != null)
             {
                 try
                 {
-                    imageSize = new Size2(imageTexture.Description.Width, imageTexture.Description.Height);
+                    imageSize = new SharpDX.Size2(imageTexture.Description.Width, imageTexture.Description.Height);
                 }
                 catch (Exception e)
                 {
@@ -49,7 +49,7 @@ namespace T3.Operators.Types.Id_d8699da1_13aa_42f7_816a_88abb1d0ba06
             var rz = RotationZ.GetValue(context);
             var yaw = 0;
             var pitch = 0;
-            var roll = MathUtil.DegreesToRadians(rz);
+            var roll = rz.ToRadians();
             var posXy = PositionXy.GetValue(context);
             var posZ = PositionZ.GetValue(context);
             
@@ -111,20 +111,20 @@ namespace T3.Operators.Types.Id_d8699da1_13aa_42f7_816a_88abb1d0ba06
 
 
             var t = new Vector3(posXy.X, posXy.Y, posZ);
-            var objectToParentObject = Matrix.Transformation(scalingCenter: Vector3.Zero, scalingRotation: Quaternion.Identity, scaling: new Vector3(scale.X, scale.Y, 1), rotationCenter: Vector3.Zero,
-                                                             rotation: Quaternion.RotationYawPitchRoll(yaw, pitch, roll), translation: new Vector3(t.X, t.Y, t.Z));
+            var objectToParentObject = Math3DUtils.CreateTransformationMatrix(scalingCenter: Vector3.Zero, scalingRotation: Quaternion.Identity, scaling: new Vector3(scale.X, scale.Y, 1), rotationCenter: Vector3.Zero,
+                                                             rotation: Quaternion.CreateFromYawPitchRoll(yaw, pitch, roll), translation: new Vector3(t.X, t.Y, t.Z));
             
             // Transpose all as mem layout in hlsl constant buffer is row based
             objectToParentObject.Transpose();
             
-            _matrix[0] = objectToParentObject.Row1;
-            _matrix[1] = objectToParentObject.Row2;
-            _matrix[2] = objectToParentObject.Row3;
-            _matrix[3] = objectToParentObject.Row4;
+            _matrix[0] = objectToParentObject.Row1();
+            _matrix[1] = objectToParentObject.Row2();
+            _matrix[2] = objectToParentObject.Row3();
+            _matrix[3] = objectToParentObject.Row4();
             Result.Value = _matrix;
         }
 
-        private readonly SharpDX.Vector4[] _matrix = new SharpDX.Vector4[4];
+        private readonly Vector4[] _matrix = new Vector4[4];
         
         
         [Input(Guid = "674E048E-5A6C-4D3E-B1E0-E44603775E02")]

--- a/Operators/Types/lib/3d/mesh/_/LoadGltf.cs
+++ b/Operators/Types/lib/3d/mesh/_/LoadGltf.cs
@@ -14,6 +14,10 @@ using T3.Core.Rendering;
 using T3.Core.Resource;
 using T3.Core.Utils;
 using Buffer = SharpDX.Direct3D11.Buffer;
+using Vector3 = System.Numerics.Vector3;
+using Vector2 = System.Numerics.Vector2;
+using Vector4 = System.Numerics.Vector4;
+using T3.Core.Utils;
 
 namespace T3.Operators.Types.Id_92b18d2b_1022_488f_ab8e_a4dcca346a23
 {
@@ -99,9 +103,9 @@ namespace T3.Operators.Types.Id_92b18d2b_1022_488f_ab8e_a4dcca346a23
                                         newData.VertexBufferData[vertexIndex] = new PbrVertex
                                                                                     {
                                                                                         Position = new Vector3(position.X, position.Y, position.Z),
-                                                                                        Normal = normals == null ? Vector3.Up : normals[vertexIndex].ToSharpDx(),
-                                                                                        Tangent = Vector3.Right,
-                                                                                        Bitangent = Vector3.ForwardLH,
+                                                                                        Normal = normals == null ? VectorT3.Up : normals[vertexIndex],
+                                                                                        Tangent = VectorT3.Right,
+                                                                                        Bitangent = VectorT3.ForwardLH,
                                                                                         Texcoord = texCoords == null ? Vector2.Zero : new Vector2(texCoords[vertexIndex].X,texCoords[vertexIndex].Y) ,
                                                                                         Selection = 1,
                                                                                     };

--- a/Operators/Types/lib/3d/mesh/generate/NGonMesh.cs
+++ b/Operators/Types/lib/3d/mesh/generate/NGonMesh.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Numerics;
 using SharpDX;
 using SharpDX.Direct3D11;
 using T3.Core;
@@ -49,11 +50,11 @@ namespace T3.Operators.Types.Id_1b9977be_70cf_4dbd_8af1_1459596b6527
 
                 var textureMode = (TextureModes)(int)TextureMode.GetValue(context).Clamp(0, Enum.GetValues(typeof(TextureModes)).Length);
 
-                var rotationMatrix = Matrix.RotationYawPitchRoll(yaw, pitch, roll);
+                var rotationMatrix = Matrix4x4.CreateFromYawPitchRoll(yaw, pitch, roll);
 
                 var center = Center.GetValue(context);
 
-                var center2 = new SharpDX.Vector3(center.X, center.Y, center.Z);
+                var center2 = new Vector3(center.X, center.Y, center.Z);
                 var segments = Segments.GetValue(context).Clamp(1, 10000);
                 var verticesCount = segments + 1; // +1 for center
 
@@ -64,9 +65,9 @@ namespace T3.Operators.Types.Id_1b9977be_70cf_4dbd_8af1_1459596b6527
                 if (_indexBufferData.Length != segments)
                     _indexBufferData = new SharpDX.Int3[segments];
 
-                var normal = SharpDX.Vector3.TransformNormal(SharpDX.Vector3.ForwardLH, rotationMatrix);
-                var tangent = SharpDX.Vector3.TransformNormal(SharpDX.Vector3.Right, rotationMatrix);
-                var binormal = SharpDX.Vector3.TransformNormal(SharpDX.Vector3.Up, rotationMatrix);
+                var normal = Vector3.TransformNormal(VectorT3.ForwardLH, rotationMatrix);
+                var tangent = Vector3.TransformNormal(VectorT3.Right, rotationMatrix);
+                var binormal = Vector3.TransformNormal(VectorT3.Up, rotationMatrix);
 
                 // center
                 {
@@ -87,7 +88,7 @@ namespace T3.Operators.Types.Id_1b9977be_70cf_4dbd_8af1_1459596b6527
                                                    Normal = normal,
                                                    Tangent = tangent,
                                                    Bitangent = binormal,
-                                                   Texcoord = new SharpDX.Vector2(uCenter, vCenter),
+                                                   Texcoord = new Vector2(uCenter, vCenter),
                                                    Selection = 1,
                                                };
                 }
@@ -96,9 +97,9 @@ namespace T3.Operators.Types.Id_1b9977be_70cf_4dbd_8af1_1459596b6527
                 for (var segmentIndex = 0; segmentIndex < segments; ++segmentIndex)
                 {
                     var phi = 2 * MathF.PI * segmentIndex / segments;
-                    var p = new SharpDX.Vector3(radius * MathF.Sin(phi) * stretch.X, // starts at top
-                                                radius * MathF.Cos(phi) * stretch.Y,
-                                                0);
+                    var p = new Vector3(radius * MathF.Sin(phi) * stretch.X, // starts at top
+                                        radius * MathF.Cos(phi) * stretch.Y,
+                                        0);
                     float u0 = 0f, v0 = 0f;
 
                     switch (textureMode)
@@ -117,8 +118,8 @@ namespace T3.Operators.Types.Id_1b9977be_70cf_4dbd_8af1_1459596b6527
                             break;
                     }
 
-                    var uv0 = new SharpDX.Vector2(u0, v0);
-                    var posRotated = SharpDX.Vector3.TransformNormal(p, rotationMatrix);
+                    var uv0 = new Vector2(u0, v0);
+                    var posRotated = Vector3.TransformNormal(p, rotationMatrix);
                     _vertexBufferData[segmentIndex + 1] = new PbrVertex
                                                               {
                                                                   Position = posRotated + center2,

--- a/Operators/Types/lib/3d/mesh/generate/QuadMesh.cs
+++ b/Operators/Types/lib/3d/mesh/generate/QuadMesh.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Numerics;
 using SharpDX;
 using SharpDX.Direct3D11;
 using T3.Core;
@@ -37,21 +38,21 @@ namespace T3.Operators.Types.Id_9d6dbf28_9983_4584_abba_6281ce51d583
                 var pivot = Pivot.GetValue(context);
                 var rotation = Rotation.GetValue(context);
                 
-                float yaw = MathUtil.DegreesToRadians(rotation.Y);
-                float pitch = MathUtil.DegreesToRadians(rotation.X);
-                float roll = MathUtil.DegreesToRadians(rotation.Z);
+                float yaw = rotation.Y.ToRadians();
+                float pitch = rotation.X.ToRadians();
+                float roll = rotation.Z.ToRadians();
 
-                var rotationMatrix = Matrix.RotationYawPitchRoll(yaw, pitch, roll);
+                var rotationMatrix = Matrix4x4.CreateFromYawPitchRoll(yaw, pitch, roll);
                 
                 //var offset = 
                 
                 var center = Center.GetValue(context);
-                //var centerRotated = SharpDX.Vector3.Transform(new SharpDX.Vector3(center.X, center.Y, center.Z), rotationMatrix);
-                var offset = new SharpDX.Vector3(stretch.X * scale * (pivot.X - 0.5f),
+                //var centerRotated = Vector3.Transform(new SharpDX.Vector3(center.X, center.Y, center.Z), rotationMatrix);
+                var offset = new Vector3(stretch.X * scale * (pivot.X - 0.5f),
                                                  stretch.Y * scale * (pivot.Y - 0.5f),
                                                  0);
 
-                var center2 = new SharpDX.Vector3(center.X, center.Y, center.Z);
+                var center2 = new Vector3(center.X, center.Y, center.Z);
 
                 var segments = Segments.GetValue(context);
                 var columns = segments.Width.Clamp(1, 10000) + 1;
@@ -70,13 +71,13 @@ namespace T3.Operators.Types.Id_9d6dbf28_9983_4584_abba_6281ce51d583
                 double columnStep = (scale * stretch.X) / (columns-1);  
                 double rowStep = (scale * stretch.Y) / (rows-1);
 
-                // var normal = SharpDX.Vector3.ForwardRH;
-                // var tangent = SharpDX.Vector3.Right;
-                // var binormal = SharpDX.Vector3.Up;
+                // var normal = VectorT3.ForwardRH;
+                // var tangent = VectorT3.Right;
+                // var binormal = VectorT3.Up;
 
-                var normal = SharpDX.Vector3.TransformNormal(SharpDX.Vector3.ForwardLH, rotationMatrix);
-                var tangent = SharpDX.Vector3.TransformNormal(SharpDX.Vector3.Right, rotationMatrix);
-                var binormal = SharpDX.Vector3.TransformNormal(SharpDX.Vector3.Up, rotationMatrix);
+                var normal = Vector3.TransformNormal(VectorT3.ForwardLH, rotationMatrix);
+                var tangent = Vector3.TransformNormal(VectorT3.Right, rotationMatrix);
+                var binormal = Vector3.TransformNormal(VectorT3.Up, rotationMatrix);
 
                 // Initialize
                 for (int columnIndex = 0; columnIndex < columns; ++columnIndex)
@@ -95,15 +96,15 @@ namespace T3.Operators.Types.Id_9d6dbf28_9983_4584_abba_6281ce51d583
                         var faceIndex =  2 * (rowIndex + columnIndex * (rows-1));
                         
                         
-                        var p = new SharpDX.Vector3(columnFragment,
+                        var p = new Vector3(columnFragment,
                                                     rowFragment, 
                                                     0);
                         
                         var v0 = (rowIndex ) / ((float)rows-1);
-                        var uv0 = new SharpDX.Vector2(u0, v0);
+                        var uv0 = new Vector2(u0, v0);
                         _vertexBufferData[vertexIndex + 0] = new PbrVertex
                                                                  {
-                                                                     Position = SharpDX.Vector3.TransformNormal(p + offset, rotationMatrix) + center2,
+                                                                     Position = Vector3.TransformNormal(p + offset, rotationMatrix) + center2,
                                                                      Normal = normal,
                                                                      Tangent = tangent,
                                                                      Bitangent = binormal,

--- a/Operators/Types/lib/3d/mesh/generate/SphereMesh.cs
+++ b/Operators/Types/lib/3d/mesh/generate/SphereMesh.cs
@@ -63,8 +63,8 @@ namespace T3.Operators.Types.Id_5fb3dafe_aed4_4fff_a5b9_c144ea023d35
 
                     if (isTop || isBottom)
                     {
-                        var normalPol0 = radius > 0 ? SharpDX.Vector3.Up : SharpDX.Vector3.Down;
-                        var normalPol1 = radius > 0 ?SharpDX.Vector3.Down : SharpDX.Vector3.Up;
+                        var normalPol0 = radius > 0 ? VectorT3.Up : VectorT3.Down;
+                        var normalPol1 = radius > 0 ? VectorT3.Down : VectorT3.Up;
 
                         for (int uIndex = 0; uIndex < uSegments; ++uIndex)
                         {
@@ -72,18 +72,18 @@ namespace T3.Operators.Types.Id_5fb3dafe_aed4_4fff_a5b9_c144ea023d35
                             var uAngle = uIndex * uAngleFraction;
 
                             // top
-                            var tangentPol0 = SharpDX.Vector3.Normalize(new SharpDX.Vector3(MathF.Sin((float)uAngle),
-                                                                                            0,
-                                                                                            MathF.Cos((float)uAngle)));
-                            var binormalPol0 = SharpDX.Vector3.Normalize(new SharpDX.Vector3(MathF.Sin((float)uAngle + MathF.PI / 2),
-                                                                                             0,
-                                                                                             MathF.Cos((float)uAngle + MathF.PI / 2)));
+                            var tangentPol0 = Vector3.Normalize(new Vector3(MathF.Sin((float)uAngle),
+                                                                                    0,
+                                                                                    MathF.Cos((float)uAngle)));
+                            var binormalPol0 = Vector3.Normalize(new Vector3(MathF.Sin((float)uAngle + MathF.PI / 2),
+                                                                                    0,
+                                                                                    MathF.Cos((float)uAngle + MathF.PI / 2)));
 
-                            var pPol0 = new SharpDX.Vector3(0,
-                                                            radius,
-                                                            0);
+                            var pPol0 = new Vector3(0,
+                                                    radius,
+                                                    0);
 
-                            var uv0 = new SharpDX.Vector2(u0, 1);
+                            var uv0 = new Vector2(u0, 1);
 
                             _vertexBufferData[0 + uIndex] = new PbrVertex
                                                                 {
@@ -97,18 +97,18 @@ namespace T3.Operators.Types.Id_5fb3dafe_aed4_4fff_a5b9_c144ea023d35
 
                             
                             // bottom
-                            var tangentPol1 = SharpDX.Vector3.Normalize(new SharpDX.Vector3(MathF.Sin((float)uAngle +  MathF.PI / 2),
-                                                                                            0,
-                                                                                            MathF.Cos((float)uAngle + MathF.PI / 2)));
-                            var binormalPol1 = SharpDX.Vector3.Normalize(new SharpDX.Vector3(MathF.Sin((float)uAngle),
-                                                                                             0,
-                                                                                             MathF.Cos((float)uAngle )));
+                            var tangentPol1 = Vector3.Normalize(new Vector3(MathF.Sin((float)uAngle +  MathF.PI / 2),
+                                                                                    0,
+                                                                                    MathF.Cos((float)uAngle + MathF.PI / 2)));
+                            var binormalPol1 = Vector3.Normalize(new Vector3(MathF.Sin((float)uAngle),
+                                                                                    0,
+                                                                                    MathF.Cos((float)uAngle )));
 
-                            var pPol1 = new SharpDX.Vector3(0,
-                                                            -radius,
-                                                            0);
+                            var pPol1 = new Vector3(0,
+                                                    -radius,
+                                                    0);
 
-                            var uv1 = new SharpDX.Vector2(u0, 0);
+                            var uv1 = new Vector2(u0, 0);
 
                             _vertexBufferData[ (vSegments - 1) * uSegments + uIndex] = new PbrVertex
                                                                 {
@@ -144,16 +144,16 @@ namespace T3.Operators.Types.Id_5fb3dafe_aed4_4fff_a5b9_c144ea023d35
                             var u0 = (uIndex) / (float)(uSegments - 1);
                             var uAngle = uIndex * uAngleFraction;
 
-                            var p = new SharpDX.Vector3((float)(Math.Sin(uAngle) * radius1),
+                            var p = new Vector3((float)(Math.Sin(uAngle) * radius1),
                                                         (float)tubePosition1Y,
                                                         (float)(Math.Cos(uAngle) * radius1)
                                                        );
 
-                            var uv0 = new SharpDX.Vector2(u0, v0);
+                            var uv0 = new Vector2(u0, v0);
 
-                            var normal0 = SharpDX.Vector3.Normalize(p);
-                            var tangent0 = SharpDX.Vector3.Normalize(new SharpDX.Vector3(normal0.Z, 0, -normal0.X));
-                            var binormal0 = SharpDX.Vector3.Cross(normal0, tangent0);
+                            var normal0 = Vector3.Normalize(p);
+                            var tangent0 = Vector3.Normalize(new Vector3(normal0.Z, 0, -normal0.X));
+                            var binormal0 = Vector3.Cross(normal0, tangent0);
 
                             _vertexBufferData[vVertexIndex + uIndex] = new PbrVertex
                                                                            {

--- a/Operators/Types/lib/3d/mesh/generate/TorusMesh.cs
+++ b/Operators/Types/lib/3d/mesh/generate/TorusMesh.cs
@@ -28,16 +28,7 @@ namespace T3.Operators.Types.Id_a835ab86_29c1_438e_a7f7_2e297108bfd5
 
         private void Update(EvaluationContext context)
         {
-            try
-            {
-                var resourceManager = ResourceManager.Instance();
-
-                var majorRadius = Radius.GetValue(context);
-                var tubeRadius = Thickness.GetValue(context);
-
-                var segments = Segments.GetValue(context);
-                var radiusSegments = segments.Width.Clamp(1, 10000) + 1;
-                var tubeSegments = segments.Height.Clamp(1, 10000) + 1;
+            try { var resourceManager = ResourceManager.Instance(); var majorRadius = Radius.GetValue(context); var tubeRadius = Thickness.GetValue(context); var segments = Segments.GetValue(context); var radiusSegments = segments.Width.Clamp(1, 10000) + 1; var tubeSegments = segments.Height.Clamp(1, 10000) + 1;
 
                 var spin = Spin.GetValue(context);
                 var radiusSpin = spin.X * MathUtils.ToRad;
@@ -87,25 +78,25 @@ namespace T3.Operators.Types.Id_a835ab86_29c1_438e_a7f7_2e297108bfd5
 
                         var radiusAngle = radiusIndex * radiusAngleFraction + radiusSpin;
 
-                        var p = new SharpDX.Vector3((float)(Math.Sin(radiusAngle) * (tubePosition1X + majorRadius)),
+                        var p = new Vector3((float)(Math.Sin(radiusAngle) * (tubePosition1X + majorRadius)),
                                                     (float)(Math.Cos(radiusAngle) * (tubePosition1X + majorRadius)), 
                                                     (float)tubePosition1Y);
                         
-                        var p1 = new SharpDX.Vector3((float)(Math.Sin(radiusAngle + radiusAngleFraction) * (tubePosition1X + majorRadius)),
+                        var p1 = new Vector3((float)(Math.Sin(radiusAngle + radiusAngleFraction) * (tubePosition1X + majorRadius)),
                                                      (float)(Math.Cos(radiusAngle + radiusAngleFraction) * (tubePosition1X + majorRadius)), 
                                                      (float)tubePosition1Y);
                         
-                        var p2 = new SharpDX.Vector3((float)(Math.Sin(radiusAngle) * (tubePosition2X + majorRadius)),
+                        var p2 = new Vector3((float)(Math.Sin(radiusAngle) * (tubePosition2X + majorRadius)),
                                                      (float)(Math.Cos(radiusAngle) * (tubePosition2X + majorRadius)), 
                                                      (float)tubePosition2Y);
                         
-                        var uv0 = new SharpDX.Vector2(u0, v1);
-                        var uv1 = new SharpDX.Vector2(u1, v1);
-                        var uv2 = new SharpDX.Vector2(u1, v0);
+                        var uv0 = new Vector2(u0, v1);
+                        var uv1 = new Vector2(u1, v1);
+                        var uv2 = new Vector2(u1, v0);
 
-                        var tubeCenter1 = new SharpDX.Vector3((float)Math.Sin(radiusAngle), (float)Math.Cos(radiusAngle), 0.0f) * majorRadius;
-                        var normal0 = SharpDX.Vector3.Normalize(useFlatShading 
-                                                                    ? SharpDX.Vector3.Cross(p - p1, p - p2) 
+                        var tubeCenter1 = new Vector3((float)Math.Sin(radiusAngle), (float)Math.Cos(radiusAngle), 0.0f) * majorRadius;
+                        var normal0 = Vector3.Normalize(useFlatShading 
+                                                                    ? Vector3.Cross(p - p1, p - p2) 
                                                                     : p - tubeCenter1);
                         
                         MeshUtils.CalcTBNSpace(p, uv0, p1, uv1, p2, uv2, normal0, out var tangent0, out var binormal0);

--- a/Operators/Types/lib/3d/rendering/_/GetCamProperties2.cs
+++ b/Operators/Types/lib/3d/rendering/_/GetCamProperties2.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 using T3.Core;
 using T3.Core.Logging;
 using T3.Core.Operator;
@@ -18,10 +19,10 @@ namespace T3.Operators.Types.Id_5b538cf5_e3b6_4674_b23e_ab55fc59ada6
         public readonly Slot<Vector3> Position = new();
 
         [Output(Guid = "F9A31409-323C-43C8-B850-624050EA229E")]
-        public readonly Slot<SharpDX.Vector4[]> CamToWorldRows = new();
+        public readonly Slot<Vector4[]> CamToWorldRows = new();
 
         [Output(Guid = "40BD0840-10AD-46CD-B8E7-0BAD72222C32")]
-        public readonly Slot<SharpDX.Vector4[]> WorldToClipSpaceRows = new();
+        public readonly Slot<Vector4[]> WorldToClipSpaceRows = new();
 
         [Output(Guid = "0FDF4500-9582-49A5-B383-6ECAE14D8DD5")]
         public readonly Slot<int> CameraCount = new();
@@ -81,17 +82,17 @@ namespace T3.Operators.Types.Id_5b538cf5_e3b6_4674_b23e_ab55fc59ada6
 
             CamToWorldRows.Value = new[]
                                        {
-                                           camToWorld.Row1,
-                                           camToWorld.Row2,
-                                           camToWorld.Row3,
-                                           camToWorld.Row4,
+                                           camToWorld.Row1(),
+                                           camToWorld.Row2(),
+                                           camToWorld.Row3(),
+                                           camToWorld.Row4(),
                                        };
             WorldToClipSpaceRows.Value = new[]
                                              {
-                                                 cam.CameraToClipSpace.Row1,
-                                                 cam.CameraToClipSpace.Row2,
-                                                 cam.CameraToClipSpace.Row3,
-                                                 cam.CameraToClipSpace.Row4,
+                                                 cam.CameraToClipSpace.Row1(),
+                                                 cam.CameraToClipSpace.Row2(),
+                                                 cam.CameraToClipSpace.Row3(),
+                                                 cam.CameraToClipSpace.Row4(),
                                              };
 
             // Prevent double evaluation when accessing multiple outputs

--- a/Operators/Types/lib/3d/transform/Camera.cs
+++ b/Operators/Types/lib/3d/transform/Camera.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Numerics;
 using SharpDX;
 using T3.Core;
 using T3.Core.DataTypes;
@@ -10,6 +11,7 @@ using T3.Core.Operator.Slots;
 using T3.Core.Resource;
 using T3.Core.Utils;
 using T3.Operators.Utils;
+using Vector3 = System.Numerics.Vector3;
 
 namespace T3.Operators.Types.Id_746d886c_5ab6_44b1_bb15_f3ce2fadf7e6
 {
@@ -41,7 +43,7 @@ namespace T3.Operators.Types.Id_746d886c_5ab6_44b1_bb15_f3ce2fadf7e6
             
             System.Numerics.Vector2 clip = NearFarClip.GetValue(context);
             var viewPortShift = ViewportShift.GetValue(context);
-            var m = Matrix.PerspectiveFovRH(fov, aspectRatio, clip.X, clip.Y);
+            var m = Math3DUtils.PerspectiveFovRH(fov, aspectRatio, clip.X, clip.Y);
             m.M31 = viewPortShift.X;
             m.M32 = viewPortShift.Y;
             CameraToClipSpace = m;
@@ -51,20 +53,20 @@ namespace T3.Operators.Types.Id_746d886c_5ab6_44b1_bb15_f3ce2fadf7e6
             var positionValue = Position.GetValue(context);
             var eye = new Vector3(positionValue.X, positionValue.Y, positionValue.Z);
             if (!offsetAffectsTarget)
-                eye += pOffset.ToSharpDx();
+                eye += pOffset;
             
             var targetValue = Target.GetValue(context);
             var target = new Vector3(targetValue.X, targetValue.Y, targetValue.Z);
             var upValue = Up.GetValue(context);
             var up = new Vector3(upValue.X, upValue.Y, upValue.Z);
-            var worldToCameraRoot = Matrix.LookAtRH(eye, target, up);
+            var worldToCameraRoot = Math3DUtils.LookAtRH(eye, target, up);
 
-            var rollRotation = Matrix.RotationAxis(new Vector3(0, 0, 1), -(float)Roll.GetValue(context));
+            var rollRotation = Matrix4x4.CreateFromAxisAngle(new Vector3(0, 0, 1), -(float)Roll.GetValue(context));
             
-            var additionalTranslation = offsetAffectsTarget ?  Matrix.Translation(pOffset.X, pOffset.Y, pOffset.Z) : Matrix.Identity;
+            var additionalTranslation = offsetAffectsTarget ?  Matrix4x4.CreateTranslation(pOffset.X, pOffset.Y, pOffset.Z) : Matrix4x4.Identity;
 
             var rOffset = RotationOffset.GetValue(context);
-            var additionalRotation = Matrix.RotationYawPitchRoll(MathUtil.DegreesToRadians(rOffset.Y),
+            var additionalRotation = Matrix4x4.CreateFromYawPitchRoll(MathUtil.DegreesToRadians(rOffset.Y),
                                                                  MathUtil.DegreesToRadians(rOffset.X),
                                                                  MathUtil.DegreesToRadians(rOffset.Z));
             
@@ -90,9 +92,9 @@ namespace T3.Operators.Types.Id_746d886c_5ab6_44b1_bb15_f3ce2fadf7e6
             context.WorldToCamera = prevWorldToCamera;
         }
 
-        public Matrix CameraToClipSpace { get; set; }
-        public Matrix WorldToCamera { get; set; }
-        public Matrix LastObjectToWorld { get; set; }
+        public Matrix4x4 CameraToClipSpace { get; set; }
+        public Matrix4x4 WorldToCamera { get; set; }
+        public Matrix4x4 LastObjectToWorld { get; set; }
 
         // Implement ICamera 
         public System.Numerics.Vector3 CameraPosition

--- a/Operators/Types/lib/3d/transform/Group.cs
+++ b/Operators/Types/lib/3d/transform/Group.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Numerics;
 using SharpDX;
 using T3.Core;
 using T3.Core.DataTypes;
@@ -8,6 +9,9 @@ using T3.Core.Operator.Attributes;
 using T3.Core.Operator.Interfaces;
 using T3.Core.Operator.Slots;
 using T3.Core.Resource;
+using T3.Core.Utils;
+using Quaternion = System.Numerics.Quaternion;
+using Vector3 = System.Numerics.Vector3;
 using Vector4 = System.Numerics.Vector4;
 
 namespace T3.Operators.Types.Id_a3f64d34_1fab_4230_86b3_1c3deba3f90b
@@ -39,8 +43,8 @@ namespace T3.Operators.Types.Id_a3f64d34_1fab_4230_86b3_1c3deba3f90b
             var pitch = MathUtil.DegreesToRadians(r.X);
             var roll = MathUtil.DegreesToRadians(r.Z);
             var t = Translation.GetValue(context);
-            var objectToParentObject = Matrix.Transformation(scalingCenter: Vector3.Zero, scalingRotation: Quaternion.Identity, scaling: new Vector3(s.X, s.Y, s.Z), rotationCenter: Vector3.Zero,
-                                                             rotation: Quaternion.RotationYawPitchRoll(yaw, pitch, roll), translation: new Vector3(t.X, t.Y, t.Z));
+            var objectToParentObject = Math3DUtils.CreateTransformationMatrix(scalingCenter: Vector3.Zero, scalingRotation: Quaternion.Identity, scaling: new Vector3(s.X, s.Y, s.Z), rotationCenter: Vector3.Zero,
+                                                             rotation: Quaternion.CreateFromYawPitchRoll(yaw, pitch, roll), translation: new Vector3(t.X, t.Y, t.Z));
 
             var forceColorUpdate = ForceColorUpdate.GetValue(context);
             var previousColor = context.ForegroundColor;
@@ -50,7 +54,7 @@ namespace T3.Operators.Types.Id_a3f64d34_1fab_4230_86b3_1c3deba3f90b
             context.ForegroundColor *= color;
             
             var previousWorldTobject = context.ObjectToWorld;
-            context.ObjectToWorld = Matrix.Multiply(objectToParentObject, context.ObjectToWorld);
+            context.ObjectToWorld = Matrix4x4.Multiply(objectToParentObject, context.ObjectToWorld);
             
             var commands = Commands.CollectedInputs;
             if (IsEnabled.GetValue(context))

--- a/Operators/Types/lib/3d/transform/OrthographicCamera.cs
+++ b/Operators/Types/lib/3d/transform/OrthographicCamera.cs
@@ -1,11 +1,13 @@
 using System;
-using SharpDX;
+using System.Numerics;
 using T3.Core.DataTypes;
 using T3.Core.Operator;
 using T3.Core.Operator.Attributes;
 using T3.Core.Operator.Interfaces;
 using T3.Core.Operator.Slots;
+using T3.Core.Utils;
 using T3.Operators.Utils;
+using Vector3 = System.Numerics.Vector3;
 
 namespace T3.Operators.Types.Id_954af16f_b37b_4e64_a965_4bec02b9179e
 {
@@ -27,7 +29,7 @@ namespace T3.Operators.Types.Id_954af16f_b37b_4e64_a965_4bec02b9179e
         {
             System.Numerics.Vector2 size = Size.GetValue(context);
             System.Numerics.Vector2 clip = NearFarClip.GetValue(context);
-            CameraToClipSpace = Matrix.OrthoRH(size.X, size.Y, clip.X, clip.Y);
+            CameraToClipSpace = Matrix4x4.CreateOrthographic(size.X, size.Y, clip.X, clip.Y);
             LastObjectToWorld = context.ObjectToWorld;
             
             var pos = Position.GetValue(context);
@@ -36,7 +38,7 @@ namespace T3.Operators.Types.Id_954af16f_b37b_4e64_a965_4bec02b9179e
             Vector3 target = new Vector3(t.X, t.Y, t.Z);
             var u = Up.GetValue(context);
             Vector3 up = new Vector3(u.X, u.Y, u.Z);
-            WorldToCamera = Matrix.LookAtRH(eye, target, up);
+            WorldToCamera = Math3DUtils.LookAtRH(eye, target, up);
 
             var prevCameraToClipSpace = context.CameraToClipSpace;
             context.CameraToClipSpace = CameraToClipSpace;
@@ -90,8 +92,8 @@ namespace T3.Operators.Types.Id_954af16f_b37b_4e64_a965_4bec02b9179e
 
         }
         
-        public Matrix WorldToCamera { get; set; }
-        public Matrix LastObjectToWorld { get; set; }
-        public Matrix CameraToClipSpace { get; set; }
+        public Matrix4x4 WorldToCamera { get; set; }
+        public Matrix4x4 LastObjectToWorld { get; set; }
+        public Matrix4x4 CameraToClipSpace { get; set; }
     }
 }

--- a/Operators/Types/lib/3d/transform/RotateAroundAxis.cs
+++ b/Operators/Types/lib/3d/transform/RotateAroundAxis.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Numerics;
 using SharpDX;
 using T3.Core.DataTypes;
 using T3.Core.Operator;
@@ -24,10 +25,10 @@ namespace T3.Operators.Types.Id_a6e12383_09b6_4bbd_a4bb_8908598c3409
             var vector3 = Axis.GetValue(context);
             var angle = Angle.GetValue(context) / 180 * MathF.PI;
             
-            Matrix m = Matrix.RotationAxis(vector3.ToSharpDxVector3(), angle);
+            Matrix4x4 m = Matrix4x4.CreateFromAxisAngle(vector3, angle);
             
             var previousWorldTobject = context.ObjectToWorld;
-            context.ObjectToWorld = Matrix.Multiply(m, context.ObjectToWorld);
+            context.ObjectToWorld = Matrix4x4.Multiply(m, context.ObjectToWorld);
             Command.GetValue(context);
             context.ObjectToWorld = previousWorldTobject;
         }

--- a/Operators/Types/lib/3d/transform/RotateTowards.cs
+++ b/Operators/Types/lib/3d/transform/RotateTowards.cs
@@ -1,9 +1,12 @@
+using System.Numerics;
 using SharpDX;
 using T3.Core.DataTypes;
 using T3.Core.Operator;
 using T3.Core.Operator.Attributes;
 using T3.Core.Operator.Slots;
 using T3.Core.Utils;
+using Vector3 = System.Numerics.Vector3;
+using Vector4 = System.Numerics.Vector4;
 
 namespace T3.Operators.Types.Id_8373c170_a140_4ce4_b59b_47f42fb71700
 {
@@ -26,31 +29,31 @@ namespace T3.Operators.Types.Id_8373c170_a140_4ce4_b59b_47f42fb71700
             if (targetMode == Modes.TowardsCamera)
             {
                 //TransformCallback?.Invoke(this, context); // this this is stupid stupid
-                SharpDX.Matrix camToWorld = context.WorldToCamera;
+                Matrix4x4 camToWorld = context.WorldToCamera;
                 camToWorld.Invert();
-                targetPosDx = SharpDX.Vector4.Transform(new SharpDX.Vector4(0f, 0f, 0f, 1f), camToWorld).ToVector3();
+                targetPosDx = Vector4.Transform(new Vector4(0f, 0f, 0f, 1f), camToWorld).ToVector3();
             }
             else
             {
-                targetPosDx = targetPos.ToSharpDx();
+                targetPosDx = targetPos;
             }
             
-            var sourcePos = SharpDX.Vector4.Transform( new Vector4(0,0,0,1), context.ObjectToWorld).ToVector3();
+            var sourcePos = Vector4.Transform( new Vector4(0,0,0,1), context.ObjectToWorld).ToVector3();
             
-            var lookAt = Matrix.LookAtRH(Vector3.Zero , -targetPosDx + sourcePos, Vector3.Up);
+            var lookAt = Math3DUtils.LookAtRH(Vector3.Zero , -targetPosDx + sourcePos, VectorT3.Up);
             lookAt.Invert();
 
             var rotationOffset = RotationOffset.GetValue(context);
-            var rotateOffset = Matrix.RotationYawPitchRoll(
-                                                           rotationOffset.Y.ToRadians(),
-                                                           rotationOffset.X.ToRadians(),
-                                                           rotationOffset.Z.ToRadians());
+            var rotateOffset = Matrix4x4.CreateFromYawPitchRoll(
+                                                             rotationOffset.Y.ToRadians(),
+                                                             rotationOffset.X.ToRadians(),
+                                                             rotationOffset.Z.ToRadians());
 
-            lookAt = Matrix.Multiply( rotateOffset, lookAt);
+            lookAt = Matrix4x4.Multiply( rotateOffset, lookAt);
             
             
             var previousWorldTobject = context.ObjectToWorld;
-            context.ObjectToWorld = Matrix.Multiply(lookAt, context.ObjectToWorld);
+            context.ObjectToWorld = Matrix4x4.Multiply(lookAt, context.ObjectToWorld);
             Command.GetValue(context);
             context.ObjectToWorld = previousWorldTobject;
         }

--- a/Operators/Types/lib/3d/transform/Shear.cs
+++ b/Operators/Types/lib/3d/transform/Shear.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Numerics;
 using SharpDX;
 using T3.Core;
 using T3.Core.DataTypes;
@@ -25,14 +26,14 @@ namespace T3.Operators.Types.Id_c3d35057_2544_4b82_b2de_b70fe205662b
         {
             var shearing = Translation.GetValue(context);
             
-            Matrix m = Matrix.Identity;
+            Matrix4x4 m = Matrix4x4.Identity;
             
             m.M12=shearing.Y; 
             m.M21=shearing.X; 
             m.M14=shearing.Z; 
 
             var previousWorldTobject = context.ObjectToWorld;
-            context.ObjectToWorld = Matrix.Multiply(m, context.ObjectToWorld);
+            context.ObjectToWorld = Matrix4x4.Multiply(m, context.ObjectToWorld);
             Command.GetValue(context);
             context.ObjectToWorld = previousWorldTobject;
         }

--- a/Operators/Types/lib/3d/transform/SliceViewPort.cs
+++ b/Operators/Types/lib/3d/transform/SliceViewPort.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Numerics;
 using SharpDX;
 using SharpDX.Direct3D11;
 using SharpDX.Mathematics.Interop;
@@ -118,7 +119,7 @@ namespace T3.Operators.Types.Id_8b888408_e472_4bf9_be25_17a3dd8b90fd
         public readonly InputSlot<int> Mode = new ();
         
         private RasterizerState _prevRasterizerState;
-        private Matrix _prevCameraToClipSpace;
+        private Matrix4x4 _prevCameraToClipSpace;
 
         private enum ViewModes
         {

--- a/Operators/Types/lib/3d/transform/SpreadLayout.cs
+++ b/Operators/Types/lib/3d/transform/SpreadLayout.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Numerics;
 using SharpDX;
 using T3.Core;
 using T3.Core.DataTypes;
@@ -9,6 +10,8 @@ using T3.Core.Operator.Interfaces;
 using T3.Core.Operator.Slots;
 using T3.Core.Resource;
 using T3.Core.Utils;
+using Quaternion = System.Numerics.Quaternion;
+using Vector3 = System.Numerics.Vector3;
 using Vector4 = System.Numerics.Vector4;
 
 namespace T3.Operators.Types.Id_e07550cf_033a_443d_b6f3_73eb71c72d9d
@@ -68,12 +71,12 @@ namespace T3.Operators.Types.Id_e07550cf_033a_443d_b6f3_73eb71c72d9d
 
                     // Build and set transform matrix
                     var objectToParentObject
-                        = Matrix.Transformation(scalingCenter: Vector3.Zero,
+                        = Math3DUtils.CreateTransformationMatrix(scalingCenter: Vector3.Zero,
                                                 scalingRotation: Quaternion.Identity,
-                                                scaling: s.ToSharpDx(),
+                                                scaling: s,
                                                 rotationCenter: Vector3.Zero,
-                                                rotation: Quaternion.RotationYawPitchRoll(yaw, pitch, roll),
-                                                translation: tSpreaded.ToSharpDx());
+                                                rotation: Quaternion.CreateFromYawPitchRoll(yaw, pitch, roll),
+                                                translation: tSpreaded);
 
                     var forceColorUpdate = ForceColorUpdate.GetValue(context);
                     var color = Color.GetValue(context);
@@ -81,7 +84,7 @@ namespace T3.Operators.Types.Id_e07550cf_033a_443d_b6f3_73eb71c72d9d
                     //color.W *= previousColor.W;     // TODO: this should be probably be controlled by an input parameter
                     context.ForegroundColor *= color;
 
-                    context.ObjectToWorld = Matrix.Multiply(objectToParentObject, originalObjectToWorld);
+                    context.ObjectToWorld = Matrix4x4.Multiply(objectToParentObject, originalObjectToWorld);
 
                     // Do preparation if needed
                     t1.Value?.PrepareAction?.Invoke(context);

--- a/Operators/Types/lib/3d/transform/Transform.cs
+++ b/Operators/Types/lib/3d/transform/Transform.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Numerics;
 using SharpDX;
 using T3.Core;
 using T3.Core.DataTypes;
@@ -8,6 +9,7 @@ using T3.Core.Operator.Interfaces;
 using T3.Core.Operator.Slots;
 using T3.Core.Resource;
 using T3.Core.Utils;
+using Quaternion = System.Numerics.Quaternion;
 
 namespace T3.Operators.Types.Id_284d2183_197d_47fd_b130_873cced78b1c
 {
@@ -38,16 +40,16 @@ namespace T3.Operators.Types.Id_284d2183_197d_47fd_b130_873cced78b1c
             float pitch = MathUtil.DegreesToRadians(r.X);
             float roll = MathUtil.DegreesToRadians(r.Z);
             var t = Translation.GetValue(context);
-            var objectToParentObject = Matrix.Transformation(
-                                                             scalingCenter: pivot.ToSharpDx(), 
+            var objectToParentObject = Math3DUtils.CreateTransformationMatrix(
+                                                             scalingCenter: pivot, 
                                                              scalingRotation: Quaternion.Identity, 
-                                                             scaling: s.ToSharpDx(), 
-                                                             rotationCenter: pivot.ToSharpDx(),
-                                                             rotation: Quaternion.RotationYawPitchRoll(yaw, pitch, roll), 
-                                                             translation: t.ToSharpDx());
+                                                             scaling: s, 
+                                                             rotationCenter: pivot,
+                                                             rotation: Quaternion.CreateFromYawPitchRoll(yaw, pitch, roll), 
+                                                             translation: t);
             
             var previousWorldTobject = context.ObjectToWorld;
-            context.ObjectToWorld = Matrix.Multiply(objectToParentObject, context.ObjectToWorld);
+            context.ObjectToWorld = Matrix4x4.Multiply(objectToParentObject, context.ObjectToWorld);
             Command.GetValue(context);
             context.ObjectToWorld = previousWorldTobject;
         }

--- a/Operators/Types/lib/dx11/buffer/FloatsToBuffer.cs
+++ b/Operators/Types/lib/dx11/buffer/FloatsToBuffer.cs
@@ -6,6 +6,7 @@ using T3.Core.Operator.Slots;
 using T3.Core.Resource;
 using Buffer = SharpDX.Direct3D11.Buffer;
 using Utilities = T3.Core.Utils.Utilities;
+using Vector4 = System.Numerics.Vector4;
 
 namespace T3.Operators.Types.Id_724da755_2d0c_42ab_8335_8c88ec5fb078
 {
@@ -41,10 +42,10 @@ namespace T3.Operators.Types.Id_724da755_2d0c_42ab_8335_8c88ec5fb078
                 for (var vec4Index = 0; vec4Index < vec4ArrayLength; vec4Index++)
                 {
                     var vec4 = vec4params[vec4Index];
-                    array[vec4Index * 4 + 0] = vec4[0];
-                    array[vec4Index * 4 + 1] = vec4[1];
-                    array[vec4Index * 4 + 2] = vec4[2];
-                    array[vec4Index * 4 + 3] = vec4[3];
+                    array[vec4Index * 4 + 0] = vec4.X;
+                    array[vec4Index * 4 + 1] = vec4.Y;
+                    array[vec4Index * 4 + 2] = vec4.Z;
+                    array[vec4Index * 4 + 3] = vec4.W;
                 }
             }
 
@@ -86,7 +87,7 @@ namespace T3.Operators.Types.Id_724da755_2d0c_42ab_8335_8c88ec5fb078
         }
         
         [Input(Guid = "914EA6E8-ABC6-4294-B895-8BFBE5AFEA0E")]
-        public readonly InputSlot<SharpDX.Vector4[]> Vec4Params = new();
+        public readonly InputSlot<Vector4[]> Vec4Params = new();
 
         [Input(Guid = "49556D12-4CD1-4341-B9D8-C356668D296C")]
         public readonly MultiInputSlot<float> Params = new MultiInputSlot<float>();

--- a/Operators/Types/lib/dx11/buffer/TransformsConstBuffer.cs
+++ b/Operators/Types/lib/dx11/buffer/TransformsConstBuffer.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Numerics;
+using System.Runtime.InteropServices;
 using SharpDX;
 using T3.Core;
 using T3.Core.Logging;
@@ -6,6 +7,7 @@ using T3.Core.Operator;
 using T3.Core.Operator.Attributes;
 using T3.Core.Operator.Slots;
 using T3.Core.Resource;
+using T3.Core.Utils;
 using Buffer = SharpDX.Direct3D11.Buffer;
 
 namespace T3.Operators.Types.Id_a60adc26_d7c6_4615_af78_8d2d6da46b79
@@ -31,25 +33,25 @@ namespace T3.Operators.Types.Id_a60adc26_d7c6_4615_af78_8d2d6da46b79
         [StructLayout(LayoutKind.Explicit, Size = 4*4*4*10)]
         public struct TransformBufferLayout
         {
-            public TransformBufferLayout(Matrix cameraToClipSpace, Matrix worldToCamera, Matrix objectToWorld)
+            public TransformBufferLayout(Matrix4x4 cameraToClipSpace, Matrix4x4 worldToCamera, Matrix4x4 objectToWorld)
             {
-                Matrix clipSpaceToCamera = cameraToClipSpace;
+                Matrix4x4 clipSpaceToCamera = cameraToClipSpace;
                 clipSpaceToCamera.Invert();
-                Matrix cameraToWorld = worldToCamera;
+                Matrix4x4 cameraToWorld = worldToCamera;
                 cameraToWorld.Invert();
-                Matrix worldToObject = objectToWorld;
+                Matrix4x4 worldToObject = objectToWorld;
                 worldToObject.Invert();
                 
                 CameraToClipSpace = cameraToClipSpace;
                 ClipSpaceToCamera = clipSpaceToCamera;
                 WorldToCamera = worldToCamera;
                 CameraToWorld = cameraToWorld;
-                WorldToClipSpace = Matrix.Multiply(worldToCamera, cameraToClipSpace);
-                ClipSpaceToWorld = Matrix.Multiply(clipSpaceToCamera, cameraToWorld);
+                WorldToClipSpace = Matrix4x4.Multiply(worldToCamera, cameraToClipSpace);
+                ClipSpaceToWorld = Matrix4x4.Multiply(clipSpaceToCamera, cameraToWorld);
                 ObjectToWorld = objectToWorld;
                 WorldToObject = worldToObject;
-                ObjectToCamera = Matrix.Multiply(objectToWorld, worldToCamera);
-                ObjectToClipSpace = Matrix.Multiply(ObjectToCamera, cameraToClipSpace);
+                ObjectToCamera = Matrix4x4.Multiply(objectToWorld, worldToCamera);
+                ObjectToClipSpace = Matrix4x4.Multiply(ObjectToCamera, cameraToClipSpace);
 
                 // transpose all as mem layout in hlsl constant buffer is row based
                 CameraToClipSpace.Transpose();
@@ -65,25 +67,25 @@ namespace T3.Operators.Types.Id_a60adc26_d7c6_4615_af78_8d2d6da46b79
             }
 
             [FieldOffset(0)]
-            public Matrix CameraToClipSpace;
+            public Matrix4x4 CameraToClipSpace;
             [FieldOffset(64)]
-            public Matrix ClipSpaceToCamera;
+            public Matrix4x4 ClipSpaceToCamera;
             [FieldOffset(128)]
-            public Matrix WorldToCamera;
+            public Matrix4x4 WorldToCamera;
             [FieldOffset(192)]
-            public Matrix CameraToWorld;
+            public Matrix4x4 CameraToWorld;
             [FieldOffset(256)]
-            public Matrix WorldToClipSpace;
+            public Matrix4x4 WorldToClipSpace;
             [FieldOffset(320)]
-            public Matrix ClipSpaceToWorld;
+            public Matrix4x4 ClipSpaceToWorld;
             [FieldOffset(384)]
-            public Matrix ObjectToWorld;
+            public Matrix4x4 ObjectToWorld;
             [FieldOffset(448)]
-            public Matrix WorldToObject;
+            public Matrix4x4 WorldToObject;
             [FieldOffset(512)]
-            public Matrix ObjectToCamera;
+            public Matrix4x4 ObjectToCamera;
             [FieldOffset(576)]
-            public Matrix ObjectToClipSpace;
+            public Matrix4x4 ObjectToClipSpace;
         }
     }
 }

--- a/Operators/Types/lib/exec/context/CamPosition.cs
+++ b/Operators/Types/lib/exec/context/CamPosition.cs
@@ -5,6 +5,7 @@ using T3.Core.Operator;
 using T3.Core.Operator.Attributes;
 using T3.Core.Operator.Slots;
 using T3.Core.Resource;
+using T3.Core.Utils;
 
 namespace T3.Operators.Types.Id_2ed26fb7_fe66_4ed6_8b8d_230d87ae5c77
 {
@@ -34,13 +35,13 @@ namespace T3.Operators.Types.Id_2ed26fb7_fe66_4ed6_8b8d_230d87ae5c77
         private void Update(EvaluationContext context)
         {
             
-            SharpDX.Matrix camToWorld = context.WorldToCamera;
+            Matrix4x4 camToWorld = context.WorldToCamera;
             camToWorld.Invert();
             
-            var pos = SharpDX.Vector4.Transform(new SharpDX.Vector4(0f, 0f, 0f, 1f), camToWorld);
+            var pos = Vector4.Transform(new Vector4(0f, 0f, 0f, 1f), camToWorld);
             Position.Value = new Vector3(pos.X, pos.Y, pos.Z);
             
-            var dir = pos -SharpDX.Vector4.Transform(new SharpDX.Vector4(0f, 0f, 1f, 1f), camToWorld);
+            var dir = pos -Vector4.Transform(new Vector4(0f, 0f, 1f, 1f), camToWorld);
             Direction.Value = new Vector3(dir.X, dir.Y, dir.Z);
             
             float aspect = context.CameraToClipSpace.M22 / context.CameraToClipSpace.M11;

--- a/Operators/Types/lib/exec/context/GetPosition.cs
+++ b/Operators/Types/lib/exec/context/GetPosition.cs
@@ -4,6 +4,7 @@ using T3.Core.Logging;
 using T3.Core.Operator;
 using T3.Core.Operator.Attributes;
 using T3.Core.Operator.Slots;
+using T3.Core.Utils;
 
 namespace T3.Operators.Types.Id_b7731197_b922_4ed8_8e22_bc7596c64f6c
 {
@@ -19,7 +20,7 @@ namespace T3.Operators.Types.Id_b7731197_b922_4ed8_8e22_bc7596c64f6c
         public readonly Slot<Vector3> Scale = new();
         
         [Output(Guid = "751E97DE-C418-48C7-823E-D4660073A559")]
-        public readonly Slot<SharpDX.Vector4[]> ObjectToWorld = new();
+        public readonly Slot<Vector4[]> ObjectToWorld = new();
         
         public GetPosition()
         {
@@ -38,21 +39,21 @@ namespace T3.Operators.Types.Id_b7731197_b922_4ed8_8e22_bc7596c64f6c
 
         private void Update(EvaluationContext context)
         {
-            var p = new SharpDX.Vector4(0, 0, 0, 1);
-            var pInWorld = SharpDX.Vector4.Transform(p, context.ObjectToWorld);
+            var p = new Vector4(0, 0, 0, 1);
+            var pInWorld = Vector4.Transform(p, context.ObjectToWorld);
             _lastPosition = new Vector3(pInWorld.X, pInWorld.Y, pInWorld.Z);
             
-            var s = new SharpDX.Vector4(1, 1, 1, 0);
-            var sInWorld = SharpDX.Vector4.Transform(s, context.ObjectToWorld);
+            var s = new Vector4(1, 1, 1, 0);
+            var sInWorld = Vector4.Transform(s, context.ObjectToWorld);
             _lastScale = new Vector3(sInWorld.X, sInWorld.Y, sInWorld.Z);
             
-            _matrix[0] = context.ObjectToWorld.Row1;
-            _matrix[1] = context.ObjectToWorld.Row2;
-            _matrix[2] = context.ObjectToWorld.Row3;
-            _matrix[3] = context.ObjectToWorld.Row4;
+            _matrix[0] = context.ObjectToWorld.Row1();
+            _matrix[1] = context.ObjectToWorld.Row2();
+            _matrix[2] = context.ObjectToWorld.Row3();
+            _matrix[3] = context.ObjectToWorld.Row4();
         }
 
-        private readonly SharpDX.Vector4[] _matrix = new SharpDX.Vector4[4] ;
+        private readonly Vector4[] _matrix = new Vector4[4] ;
         private Vector3 _lastPosition;
         private Vector3 _lastScale;
         

--- a/Operators/Types/lib/io/input/MouseInput.cs
+++ b/Operators/Types/lib/io/input/MouseInput.cs
@@ -1,5 +1,5 @@
 using System;
-using SharpDX;
+using System.Numerics;
 using T3.Core.Operator;
 using T3.Core.Operator.Attributes;
 using T3.Core.Operator.Slots;
@@ -44,11 +44,11 @@ namespace T3.Operators.Types.Id_eff2ffff_dc39_4b90_9b1c_3c0a9a0108c6
                     cameraToWorld.Invert();
                     
                     var posInClip =  (lastPosition - new Vector2(0.5f, 0.5f)) * new Vector2(2, -2);
-                    var posInWorld = Vector3.TransformCoordinate(new Vector3(posInClip.X, posInClip.Y, 0f), clipSpaceToWorld);
-                    var targetInWorld = Vector3.TransformCoordinate(new Vector3(posInClip.X, posInClip.Y, 1f), clipSpaceToWorld);
-                    var ray = new SharpDX.Ray(posInWorld, targetInWorld - posInWorld);
-                    var xyPlane = new Plane(SharpDX.Vector3.Zero, SharpDX.Vector3.UnitZ);
-                    if (xyPlane.Intersects(ref ray, out SharpDX.Vector3 p))
+                    var posInWorld = Vector3.Transform(new Vector3(posInClip.X, posInClip.Y, 0f), clipSpaceToWorld);
+                    var targetInWorld = Vector3.Transform(new Vector3(posInClip.X, posInClip.Y, 1f), clipSpaceToWorld);
+                    var ray = new Ray(posInWorld, targetInWorld - posInWorld);
+                    var xyPlane = PlaneExtensions.PlaneFromPointAndNormal(Vector3.Zero, Vector3.UnitZ);
+                    if (xyPlane.Intersects(in ray, out Vector3 p))
                     {
                         Position.Value = new Vector2(p.X, p.Y) ;
                     }
@@ -60,7 +60,7 @@ namespace T3.Operators.Types.Id_eff2ffff_dc39_4b90_9b1c_3c0a9a0108c6
             IsLeftButtonDown.Value = Core.IO.MouseInput.IsLeftButtonDown;
         }
 
-        private static Matrix ComposeClipSpaceToWorld(EvaluationContext context)
+        private static Matrix4x4 ComposeClipSpaceToWorld(EvaluationContext context)
         {
             var clipSpaceToCamera = context.CameraToClipSpace;
             clipSpaceToCamera.Invert();
@@ -68,7 +68,7 @@ namespace T3.Operators.Types.Id_eff2ffff_dc39_4b90_9b1c_3c0a9a0108c6
             cameraToWorld.Invert();
             var worldToObject = context.ObjectToWorld;
             worldToObject.Invert();
-            var clipSpaceToWorld = Matrix.Multiply(clipSpaceToCamera, cameraToWorld);
+            var clipSpaceToWorld = Matrix4x4.Multiply(clipSpaceToCamera, cameraToWorld);
             return clipSpaceToWorld;
         }
 

--- a/Operators/Types/lib/math/vec3/RotateVector3.cs
+++ b/Operators/Types/lib/math/vec3/RotateVector3.cs
@@ -25,7 +25,7 @@ namespace T3.Operators.Types.Id_ce7c2103_3669_4c7a_ba61_a10428b9d467
             var angle = Angle.GetValue(context) / 180 * MathF.PI;
             
             Matrix m = Matrix.RotationAxis(axis.ToSharpDxVector3(), angle);
-            Result.Value = SharpDX.Vector3.TransformNormal(vec.ToSharpDx(), m).ToNumerics() * Scale.GetValue(context);
+            Result.Value = Vector3.TransformNormal(vec.ToSharpDx(), m).ToNumerics() * Scale.GetValue(context);
         }
         
         [Input(Guid = "56229f73-cbe2-4279-a659-d70d32e0df59")]

--- a/Operators/Types/lib/point/_cpu/LinePointsCpu.cs
+++ b/Operators/Types/lib/point/_cpu/LinePointsCpu.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Resources;
 using Microsoft.Win32;
-using SharpDX;
 using T3.Core;
 using T3.Core.DataTypes;
 using T3.Core.Operator;
@@ -11,7 +10,6 @@ using T3.Core.Operator.Slots;
 using Point = T3.Core.DataTypes.Point;
 using Quaternion = System.Numerics.Quaternion;
 using Vector3 = System.Numerics.Vector3;
-using Vector4 = SharpDX.Vector4;
 
 namespace T3.Operators.Types.Id_a98d7796_6e09_45d1_a372_f3ea55abd359
 {

--- a/Operators/Types/lib/point/_cpu/LinearPointsCpu.cs
+++ b/Operators/Types/lib/point/_cpu/LinearPointsCpu.cs
@@ -10,8 +10,6 @@ using T3.Core.Operator.Slots;
 using T3.Core.Resource;
 using T3.Core.Utils;
 
-//using Quaternion = SharpDX.Quaternion;
-//using Vector4 = SharpDX.Vector4;
 
 namespace T3.Operators.Types.Id_796a5efb_2ccf_4cae_b01c_d3f20a070181
 {

--- a/Operators/Types/lib/point/_cpu/RepeatAtPointsCpu.cs
+++ b/Operators/Types/lib/point/_cpu/RepeatAtPointsCpu.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Resources;
 using Microsoft.Win32;
-using SharpDX;
 using T3.Core;
 using T3.Core.DataTypes;
 using T3.Core.Operator;
@@ -11,7 +10,6 @@ using T3.Core.Operator.Slots;
 using Point = T3.Core.DataTypes.Point;
 using Quaternion = System.Numerics.Quaternion;
 using Vector3 = System.Numerics.Vector3;
-using Vector4 = SharpDX.Vector4;
 
 namespace T3.Operators.Types.Id_478522e1_5683_4db1_a7dc_db59838eca2a
 {

--- a/Operators/Types/lib/point/_cpu/SampleSplinePoint.cs
+++ b/Operators/Types/lib/point/_cpu/SampleSplinePoint.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using SharpDX;
 using T3.Core.DataTypes;
 using T3.Core.Logging;
@@ -61,16 +62,16 @@ namespace T3.Operators.Types.Id_688230de_a3fc_4740_a12d_9e2f98cad60a
             var q = Quaternion.Slerp(p1.Orientation, p2.Orientation, f);
 
             var rot = QuaternionToMatrix(q);
-            rot = Matrix.Transpose(rot);
+            rot = Matrix4x4.Transpose(rot);
             
-            var m = Matrix.Identity;
+            var m = Matrix4x4.Identity;
             
             var prevMatrix = context.ObjectToWorld;
 
             //m = Matrix.Translation(pos.ToSharpDxVector3();
-            m = Matrix.Multiply(m, rot);
-            m = Matrix.Multiply(m, Matrix.Translation(pos.ToSharpDxVector3()));
-            context.ObjectToWorld = Matrix.Multiply(m, context.ObjectToWorld);
+            m = Matrix4x4.Multiply(m, rot);
+            m = Matrix4x4.Multiply(m, Matrix4x4.CreateTranslation(pos));
+            context.ObjectToWorld = Matrix4x4.Multiply(m, context.ObjectToWorld);
 
             context.ObjectToWorld = m;
             
@@ -91,9 +92,9 @@ namespace T3.Operators.Types.Id_688230de_a3fc_4740_a12d_9e2f98cad60a
         
 
 
-        private static Matrix QuaternionToMatrix(Quaternion quat)
+        private static Matrix4x4 QuaternionToMatrix(Quaternion quat)
         {
-            var m = Matrix.Identity; //float4x4(float4(0, 0, 0, 0), float4(0, 0, 0, 0), float4(0, 0, 0, 0), float4(0, 0, 0, 0));
+            var m = Matrix4x4.Identity; //float4x4(float4(0, 0, 0, 0), float4(0, 0, 0, 0), float4(0, 0, 0, 0), float4(0, 0, 0, 0));
 
             float x = quat.X, y = quat.Y, z = quat.Z, w = quat.W;
             float x2 = x + x, y2 = y + y, z2 = z + z;

--- a/Operators/Types/lib/point/_experimental/_SketchImpl.cs
+++ b/Operators/Types/lib/point/_experimental/_SketchImpl.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 using Newtonsoft.Json;
 using SharpDX;
 using T3.Core.Animation;
@@ -12,9 +13,10 @@ using T3.Core.Operator.Attributes;
 using T3.Core.Operator.Slots;
 using T3.Serialization;
 using Point = T3.Core.DataTypes.Point;
-using Utilities = T3.Core.Utils.Utilities;
 using Vector2 = System.Numerics.Vector2;
 using Vector3 = System.Numerics.Vector3;
+using T3.Core.Utils;
+using Vector4 = System.Numerics.Vector4;
 
 // ReSharper disable RedundantNameQualifier
 
@@ -250,18 +252,18 @@ namespace T3.Operators.Types.Id_b238b288_6e9b_4b91_bac9_3d7566416028
         private static Vector3 CalcPosInWorld(EvaluationContext context, Vector2 mousePos)
         {
             const float offsetFromCamPlane = 0.99f;
-            var posInClipSpace = new SharpDX.Vector4((mousePos.X - 0.5f) * 2, (-mousePos.Y + 0.5f) * 2, offsetFromCamPlane, 1);
-            Matrix clipSpaceToCamera = context.CameraToClipSpace;
+            var posInClipSpace = new Vector4((mousePos.X - 0.5f) * 2, (-mousePos.Y + 0.5f) * 2, offsetFromCamPlane, 1);
+            Matrix4x4 clipSpaceToCamera = context.CameraToClipSpace;
             clipSpaceToCamera.Invert();
-            Matrix cameraToWorld = context.WorldToCamera;
+            Matrix4x4 cameraToWorld = context.WorldToCamera;
             cameraToWorld.Invert();
-            Matrix worldToObject = context.ObjectToWorld;
+            Matrix4x4 worldToObject = context.ObjectToWorld;
             worldToObject.Invert();
 
-            var clipSpaceToWorld = Matrix.Multiply(clipSpaceToCamera, cameraToWorld);
-            var m = Matrix.Multiply(cameraToWorld, clipSpaceToCamera);
+            var clipSpaceToWorld = Matrix4x4.Multiply(clipSpaceToCamera, cameraToWorld);
+            var m = Matrix4x4.Multiply(cameraToWorld, clipSpaceToCamera);
             m.Invert();
-            var p = SharpDX.Vector4.Transform(posInClipSpace, clipSpaceToWorld);
+            var p = Vector4.Transform(posInClipSpace, clipSpaceToWorld);
             return new Vector3(p.X, p.Y, p.Z) / p.W;
         }
 

--- a/Operators/Types/lib/point/generate/RepetitionPoints.cs
+++ b/Operators/Types/lib/point/generate/RepetitionPoints.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 using System.Resources;
 using Microsoft.Win32;
-using SharpDX;
 using T3.Core;
 using T3.Core.DataTypes;
 using T3.Core.Operator;
@@ -10,10 +10,6 @@ using T3.Core.Operator.Attributes;
 using T3.Core.Operator.Slots;
 using T3.Core.Resource;
 using T3.Core.Utils;
-using Point = T3.Core.DataTypes.Point;
-using Quaternion = System.Numerics.Quaternion;
-using Vector3 = System.Numerics.Vector3;
-using Vector4 = SharpDX.Vector4;
 
 namespace T3.Operators.Types.Id_73d99108_f49a_48fb_aa5d_707c00abb1c2
 {
@@ -38,7 +34,7 @@ namespace T3.Operators.Types.Id_73d99108_f49a_48fb_aa5d_707c00abb1c2
             var rotateStep = Rotate.GetValue(context);
             var scaleStep = Scale.GetValue(context);
             var pivotTemp = Pivot.GetValue(context);
-            var pivot = new SharpDX.Vector3(pivotTemp.X, pivotTemp.Y, pivotTemp.Z);
+            var pivot = new Vector3(pivotTemp.X, pivotTemp.Y, pivotTemp.Z);
             
             var count = Count.GetValue(context).Clamp(1,10000);
             var listCount = count + (addSeparator ? 1:0); 
@@ -49,20 +45,20 @@ namespace T3.Operators.Types.Id_73d99108_f49a_48fb_aa5d_707c00abb1c2
                 _pointList.SetLength(listCount);
             }
 
-            SharpDX.Vector3 startTranslation = new SharpDX.Vector3(startPosition.X, startPosition.Y, startPosition.Z);
+            Vector3 startTranslation = new Vector3(startPosition.X, startPosition.Y, startPosition.Z);
 
             for (var i = 0; i < count; ++i) 
             {
                 float u = (i + 1+ offset);
                         
-                var translation = new SharpDX.Vector3(translateStep.X, translateStep.Y, translateStep.Z) * u + startTranslation;
-                var rotation = SharpDX.Quaternion.RotationYawPitchRoll(    rotateStep.X / 360.0f * (float)(2.0 * Math.PI) * u,
+                var translation = new Vector3(translateStep.X, translateStep.Y, translateStep.Z) * u + startTranslation;
+                var rotation = Quaternion.CreateFromYawPitchRoll(    rotateStep.X / 360.0f * (float)(2.0 * Math.PI) * u,
                                                                            rotateStep.Y / 360.0f * (float)(2.0 * Math.PI) * u,
                                                                            rotateStep.Z / 360.0f * (float)(2.0 * Math.PI) * u);
-                var scale = (SharpDX.Vector3.One - scaleStep) * u + SharpDX.Vector3.One;
-
-                var transform = Matrix.Transformation(scalingCenter: SharpDX.Vector3.Zero, 
-                                                      scalingRotation: SharpDX.Quaternion.Identity, 
+                var scale = (Vector3.One - (scaleStep * Vector3.One)) * u + Vector3.One;
+                
+                var transform = Math3DUtils.CreateTransformationMatrix(scalingCenter: Vector3.Zero, 
+                                                      scalingRotation: Quaternion.Identity, 
                                                       scaling: scale, 
                                                       rotationCenter: pivot, 
                                                       rotation: rotation, 
@@ -71,8 +67,8 @@ namespace T3.Operators.Types.Id_73d99108_f49a_48fb_aa5d_707c00abb1c2
                 //context.ObjectToWorld = transform * prevTransform;
                 
                 //var rot = Quaternion.CreateFromAxisAngle(new Vector3(0,1,0), (float)Math.Atan2(startPosition.X - to.X, startPosition.Y - to.Y) );
-                SharpDX.Vector4 v = new SharpDX.Vector4(0, 0, 0, 1);
-                SharpDX.Vector4.Transform(ref v, ref transform, out SharpDX.Vector4 pos);
+                Vector4 v = new Vector4(0, 0, 0, 1);
+                var pos = Vector4.Transform(v, transform);
             
                 _pointList.TypedElements[i].Position = new Vector3(pos.X, pos.Y, pos.Z);
                 _pointList.TypedElements[i].W = scale.Length() / Vector3.One.Length() + startW;

--- a/Operators/Types/lib/point/helper/LoadObjAsPoints.cs
+++ b/Operators/Types/lib/point/helper/LoadObjAsPoints.cs
@@ -57,7 +57,7 @@ namespace T3.Operators.Types.Id_ad651447_75e7_4491_a56a_f737d70c0522
             {
                 var sortAxisIndex = _sortAxisAndDirections[sorting][0];
                 var sortDirection = _sortAxisAndDirections[sorting][1];
-                sortedVertexIndices.Sort((v1, v2) => mesh.Positions[v1][sortAxisIndex].CompareTo(mesh.Positions[v2][sortAxisIndex]) * sortDirection);
+                sortedVertexIndices.Sort((v1, v2) => mesh.Positions[v1].Axis(sortAxisIndex).CompareTo(mesh.Positions[v2].Axis(sortAxisIndex)) * sortDirection);
             }
 
             // Export
@@ -92,7 +92,7 @@ namespace T3.Operators.Types.Id_ad651447_75e7_4491_a56a_f737d70c0522
                         {
                             var sortedVertexIndex = sortedVertexIndices[vertexIndex];
                             var c = (sortedVertexIndex >= mesh.Colors.Count)
-                                        ? SharpDX.Vector4.One
+                                        ? Vector4.One
                                         : mesh.Colors[sortedVertexIndex];
 
                             if (exportMode == Modes.Vertices_GrayscaleAsW)
@@ -276,10 +276,10 @@ namespace T3.Operators.Types.Id_ad651447_75e7_4491_a56a_f737d70c0522
             
             // Skip if opposite right angle
 
-            var eA = SharpDX.Vector3.Normalize(mesh.Positions[vertexIndexA] - mesh.Positions[oppositeVertexIndex]);  
-            var eB = SharpDX.Vector3.Normalize(mesh.Positions[vertexIndexB] - mesh.Positions[oppositeVertexIndex]);
+            var eA = Vector3.Normalize(mesh.Positions[vertexIndexA] - mesh.Positions[oppositeVertexIndex]);  
+            var eB = Vector3.Normalize(mesh.Positions[vertexIndexB] - mesh.Positions[oppositeVertexIndex]);
             
-            var dot = SharpDX.Vector3.Dot(eA, eB);
+            var dot = Vector3.Dot(eA, eB);
             if (MathF.Abs(dot) < 0.05)
             {
                 //Log.Debug($"Skipping triangulation line {hashForward}", this);

--- a/Operators/Types/user/cynic/research/Edtaa.cs
+++ b/Operators/Types/user/cynic/research/Edtaa.cs
@@ -11,6 +11,7 @@ using T3.Core.Operator.Slots;
 using T3.Core.Resource;
 using T3.Core.Utils;
 using Utilities = T3.Core.Utils.Utilities;
+using Vector2 = System.Numerics.Vector2;
 
 namespace T3.Operators.Types.Id_afcd4aad_8c8d_4e59_8e8e_a8c12d312200
 {
@@ -96,7 +97,7 @@ namespace T3.Operators.Types.Id_afcd4aad_8c8d_4e59_8e8e_a8c12d312200
                     _data = new float[width * height];
                     _xDist = new short[width * height];
                     _yDist = new short[width * height];
-                    _gradients = new SharpDX.Vector2[width * height];
+                    _gradients = new Vector2[width * height];
                 }
 
                 DataStream sourceStream;
@@ -224,7 +225,7 @@ namespace T3.Operators.Types.Id_afcd4aad_8c8d_4e59_8e8e_a8c12d312200
             }
         }
 
-        private float EdgeDf(SharpDX.Vector2 g, float a)
+        private float EdgeDf(Vector2 g, float a)
         {
             float df;
 
@@ -280,7 +281,7 @@ namespace T3.Operators.Types.Id_afcd4aad_8c8d_4e59_8e8e_a8c12d312200
             if (a == 0.0f)
                 return 1000000.0f; // Not an object pixel, return "very far" ("don't know yet")
 
-            var dx = new SharpDX.Vector2(xi, yi);
+            var dx = new Vector2(xi, yi);
             float di = dx.Length(); // Length of integer vector, like a traditional EDT
             float df;
             if (di == 0.0f)
@@ -472,7 +473,7 @@ namespace T3.Operators.Types.Id_afcd4aad_8c8d_4e59_8e8e_a8c12d312200
         Texture2D _distanceFieldImage;
         private short[] _xDist;
         private short[] _yDist;
-        private SharpDX.Vector2[] _gradients;
+        private Vector2[] _gradients;
         private float[] _data;
 
         private void UpdateOld(EvaluationContext context)

--- a/Operators/Utils/ICameraPropertiesProvider.cs
+++ b/Operators/Utils/ICameraPropertiesProvider.cs
@@ -1,11 +1,12 @@
-﻿using SharpDX;
+﻿
+using System.Numerics;
 
 namespace T3.Operators.Utils
 {
     public interface ICameraPropertiesProvider
     {
-        public Matrix CameraToClipSpace { get;  set; }
-        public Matrix WorldToCamera { get; set; }
-        public Matrix LastObjectToWorld { get; set; }
+        public Matrix4x4 CameraToClipSpace { get;  set; }
+        public Matrix4x4 WorldToCamera { get; set; }
+        public Matrix4x4 LastObjectToWorld { get; set; }
     }
 }


### PR DESCRIPTION
This PR refers to commit 274059f - "first - looking almost good!" . Hopefully if the first PR gets merged, this one will clean itself up. If not, I can re-PR bc lots of files were touched

I tested it, and it didn't seem to cause any regressions. This is just integrating replacements for SharpDX-based math across the entire repo so that none shall ever suffer at the hands of SharpDX.Vector3 and matrix and etc ever again

also, we should make our own SizeX and IntX - but just a single type since they're basically the same thing. VectorXInt from Unity is nice if a little long. Vector3i from Godot is nice if a little vague. IntX seems nicest but isn't consistent with Vector (which caused me personally much confusion in the beginning). idk man i'll let you decide that one ¯\_(ツ)_/¯