### PR TITLE
fix: look-up resources from (includer') parent folder

### DIFF
--- a/Core/Resource/ResourceManager.cs
+++ b/Core/Resource/ResourceManager.cs
@@ -369,10 +369,21 @@ namespace T3.Core.Resource
                 {
                     _streamReader = new StreamReader(Path.Combine(ResourcesFolder, fileName));
                 }
-                catch(DirectoryNotFoundException e )
+                catch (DirectoryNotFoundException rs_e)
                 {
-                    Log.Error($"Can't open file {ResourcesFolder}/{fileName}  {e.Message}");
-                    return null;
+                    try
+                    {
+                        _streamReader = new StreamReader(Path.Combine(
+                            new FileInfo(((System.IO.FileStream)parentStream).Name).DirectoryName.ToString(),
+                            fileName
+                        ));
+                    }
+                    catch (DirectoryNotFoundException in_e)
+                    {
+                        Log.Error($"Included file {fileName} wasn't found in {ResourcesFolder} or its parent folder " +
+                            $"({rs_e.Message}, {in_e.Message})");
+                        return null;
+                    }
                 }
                 return _streamReader.BaseStream;
             }


### PR DESCRIPTION
This would fix `#include` behavior whenever including headers relative to includers' folder.
This is the expected `#include` behavior, and would allow for more flexible ways to use these.
Also, this would allow user to embed some ready made shader libraries (such as lygia) easily.
Doesn't change current behavior beyond error messages.