### PR TITLE
add a GUI fullscreen setting for exported player

### DIFF
--- a/Core/IO/ProjectSettings.cs
+++ b/Core/IO/ProjectSettings.cs
@@ -15,6 +15,7 @@
             public string MainOperatorName = "";
             public float AudioResyncThreshold = 0.04f;
             public bool EnablePlaybackControlWithKeyboard = true;
+            public bool WindowedMode = false;
             
             public string LimitMidiDeviceCapture = null; 
         }

--- a/Editor/Gui/Windows/SettingsWindow.cs
+++ b/Editor/Gui/Windows/SettingsWindow.cs
@@ -136,6 +136,10 @@ namespace T3.Editor.Gui.Windows
                                                                  ref ProjectSettings.Config.EnablePlaybackControlWithKeyboard,
                                                                  "Users can use cursor left/right to skip through time\nand space key to pause playback\nof exported executable.",
                                                                  ProjectSettings.Defaults.EnablePlaybackControlWithKeyboard);
+                projectSettingsChanged |= FormInputs.AddCheckBox("Windowed player",
+                                                                 ref ProjectSettings.Config.WindowedMode,
+                                                                 "Run the executable in windowed mode by default.",
+                                                                 ProjectSettings.Defaults.WindowedMode);
                 if(projectSettingsChanged)
                     ProjectSettings.Save();
                 

--- a/Player/Program.cs
+++ b/Player/Program.cs
@@ -72,8 +72,7 @@ namespace T3.Player
                 _vsync = !options.NoVsync;
                 Log.Debug($"using vsync: {_vsync}, windowed: {options.Windowed}, size: {options.Size}, loop: {options.Loop}, logging: {options.Logging}");
 
-                // Todo: Should use correct title
-                var form = new RenderForm("still::partial")
+                var form = new RenderForm($"{ProjectSettings.Config.MainOperatorName}")
                                {
                                    ClientSize = options.Size,
                                    AllowUserResizing = false,
@@ -112,7 +111,7 @@ namespace T3.Player
                 var factory = _swapChain.GetParent<Factory>();
                 factory.MakeWindowAssociation(form.Handle, WindowAssociationFlags.IgnoreAll);
 
-                bool startedWindowed = options.Windowed;
+                var startedWindowed = options.Windowed;
 
                 form.KeyDown += HandleKeyDown;
                 form.KeyUp += HandleKeyUp;
@@ -409,7 +408,7 @@ namespace T3.Player
                                                   h.AdditionalNewLineAfterOption = false;
 
                                                   // Todo: This should use information from the main operator
-                                                  h.Heading = $"still::{ProjectSettings.Config.MainOperatorName} - v0.1";
+                                                  h.Heading = $"{ProjectSettings.Config.MainOperatorName}";
 
                                                   // Todo: This should use information from the main operator
                                                   h.Copyright = "Author";
@@ -420,6 +419,10 @@ namespace T3.Player
 
             parserResult.WithParsed(o => { parsedOptions = o; })
                         .WithNotParsed(o => { Log.Debug(helpText); });
+            // use windowed status _only_ when explicitly set, the Options struct doesn't know about this
+            if(!args.Any(s => "--windowed".Contains(s))) {
+                parsedOptions.Windowed = ProjectSettings.Config.WindowedMode;
+            }
             return parsedOptions;
         }
 

--- a/projectSettings.json
+++ b/projectSettings.json
@@ -3,5 +3,6 @@
   "MainOperatorName": "WFE_RoughtCut",
   "AudioResyncThreshold": 0.04,
   "EnablePlaybackControlWithKeyboard": false,
+  "WindowedMode": true,
   "LimitMidiDeviceCapture": null
 }


### PR DESCRIPTION
- enable a new "Windowed Player" option in settings, allow to set the player behavior with a better UX. (CLI options are still working as before and prioritize over what's up in `projectSettings`)
- ... if this change is good, more settings could probably be enabled (res ? vsync ?)
- also fixes a few cosmetic around player.exe (window title, some text)