### PR TITLE
fix: new fullscreen settings for many-screens setups

### DIFF
--- a/Editor/App/ProgramWindows.cs
+++ b/Editor/App/ProgramWindows.cs
@@ -11,7 +11,9 @@ using T3.Core.Logging;
 using T3.Core.Resource;
 using T3.Editor.Gui;
 using T3.Editor.Gui.UiHelpers;
+using T3.Editor.Gui.Windows.Layouts;
 using T3.Editor.SystemUi;
+using T3.Editor.UiModel;
 using T3.SystemUi;
 using Device = SharpDX.Direct3D11.Device;
 
@@ -40,6 +42,12 @@ internal static class ProgramWindows
     public static void SetVertexShader(VertexShaderResource resource) => _deviceContext.VertexShader.Set(resource.VertexShader);
     public static void SetPixelShader(PixelShaderResource resource) => _deviceContext.PixelShader.Set(resource.PixelShader);
 
+    internal static void HandleFocusModeToggle()
+    {
+        UserSettings.Config.ShowToolbar = !UserSettings.Config.FocusMode;
+        UserSettings.Config.ShowTitleAndDescription = !UserSettings.Config.FocusMode;
+        if(!UserSettings.Config.FocusMode) LayoutHandling.LoadAndApplyLayoutOrFocusMode(UserSettings.Config.WindowLayoutIndex);
+    }
     internal static void HandleFullscreenToggle()
     {
         if (Main.IsFullScreen == UserSettings.Config.FullScreen)

--- a/Editor/App/ProgramWindows.cs
+++ b/Editor/App/ProgramWindows.cs
@@ -11,9 +11,7 @@ using T3.Core.Logging;
 using T3.Core.Resource;
 using T3.Editor.Gui;
 using T3.Editor.Gui.UiHelpers;
-using T3.Editor.Gui.Windows.Layouts;
 using T3.Editor.SystemUi;
-using T3.Editor.UiModel;
 using T3.SystemUi;
 using Device = SharpDX.Direct3D11.Device;
 
@@ -42,14 +40,6 @@ internal static class ProgramWindows
     public static void SetVertexShader(VertexShaderResource resource) => _deviceContext.VertexShader.Set(resource.VertexShader);
     public static void SetPixelShader(PixelShaderResource resource) => _deviceContext.PixelShader.Set(resource.PixelShader);
 
-    internal static void HandleFocusModeToggle()
-    {
-        UserSettings.Config.ShowToolbar = !UserSettings.Config.FocusMode;
-        UserSettings.Config.ShowTitleAndDescription = !UserSettings.Config.FocusMode;
-        UserSettings.Config.ShowMainMenu = !UserSettings.Config.FocusMode;
-        UserSettings.Config.ShowTimeline = !UserSettings.Config.FocusMode;
-        if(!UserSettings.Config.FocusMode) LayoutHandling.LoadAndApplyLayoutOrFocusMode(UserSettings.Config.WindowLayoutIndex);
-    }
     internal static void HandleFullscreenToggle()
     {
         if (Main.IsFullScreen == UserSettings.Config.FullScreen)

--- a/Editor/App/ProgramWindows.cs
+++ b/Editor/App/ProgramWindows.cs
@@ -46,6 +46,8 @@ internal static class ProgramWindows
     {
         UserSettings.Config.ShowToolbar = !UserSettings.Config.FocusMode;
         UserSettings.Config.ShowTitleAndDescription = !UserSettings.Config.FocusMode;
+        UserSettings.Config.ShowMainMenu = !UserSettings.Config.FocusMode;
+        UserSettings.Config.ShowTimeline = !UserSettings.Config.FocusMode;
         if(!UserSettings.Config.FocusMode) LayoutHandling.LoadAndApplyLayoutOrFocusMode(UserSettings.Config.WindowLayoutIndex);
     }
     internal static void HandleFullscreenToggle()

--- a/Editor/App/ProgramWindows.cs
+++ b/Editor/App/ProgramWindows.cs
@@ -47,15 +47,9 @@ internal static class ProgramWindows
 
         if (UserSettings.Config.FullScreen)
         {
-            var screenCount = Screen.AllScreens.Length;
-            var hasSecondScreen = screenCount > 1;
-            var secondScreenIndex = hasSecondScreen ? 1 : 0;
-
-            var screenIndexForMainScreen = UserSettings.Config.SwapMainAnd2ndWindowsWhenFullscreen ? secondScreenIndex : 0;
-            var screenIndexForSecondScreen = UserSettings.Config.SwapMainAnd2ndWindowsWhenFullscreen ? 0 : secondScreenIndex;
-
-            Main.SetFullScreen(screenIndexForMainScreen);
-            Viewer.SetFullScreen(screenIndexForSecondScreen);
+            var ScreenCount = Screen.AllScreens.Length;
+            Main.SetFullScreen(UserSettings.Config.FullScreenIndexMain < ScreenCount ? UserSettings.Config.FullScreenIndexMain : 0);
+            Viewer.SetFullScreen(UserSettings.Config.FullScreenIndexViewer < ScreenCount ? UserSettings.Config.FullScreenIndexViewer : 0);
         }
         else
         {

--- a/Editor/Gui/T3UI.cs
+++ b/Editor/Gui/T3UI.cs
@@ -184,10 +184,15 @@ public class T3Ui
         {
             UserSettings.Config.FullScreen = !UserSettings.Config.FullScreen;
         }
-        else if (KeyboardBinding.Triggered(UserActions.ToggleFocusMode))
-        {
-            UserSettings.Config.FocusMode = !UserSettings.Config.FocusMode;
-        }
+        else if (KeyboardBinding.Triggered(UserActions.ToggleFocusMode)) ToggleFocusMode();
+    }
+
+    private static void ToggleFocusMode() {
+        var shouldBeFocusMode = !UserSettings.Config.FocusMode;
+        UserSettings.Config.FocusMode = shouldBeFocusMode;
+        UserSettings.Config.ShowToolbar = shouldBeFocusMode;
+        ToggleAllUiElements();
+        LayoutHandling.LoadAndApplyLayoutOrFocusMode(shouldBeFocusMode ? 11 : UserSettings.Config.WindowLayoutIndex);
     }
         
     private void DrawAppMenuBar()
@@ -336,7 +341,10 @@ public class T3Ui
                 }
 
                 ImGui.MenuItem("Fullscreen", KeyboardBinding.ListKeyboardShortcuts(UserActions.ToggleFullscreen, false), ref UserSettings.Config.FullScreen);
-                ImGui.MenuItem("Focus Mode", KeyboardBinding.ListKeyboardShortcuts(UserActions.ToggleFocusMode, false), ref UserSettings.Config.FocusMode);
+                if (ImGui.MenuItem("Focus Mode", KeyboardBinding.ListKeyboardShortcuts(UserActions.ToggleFocusMode, false), UserSettings.Config.FocusMode))
+                {
+                    ToggleFocusMode();
+                }
                 ImGui.EndMenu();
             }
                 
@@ -346,7 +354,6 @@ public class T3Ui
                 ImGui.EndMenu();
             }
 
-            
             if (UserSettings.Config.FullScreen)
             {
                 ImGui.Dummy(new Vector2(10,10));
@@ -368,7 +375,7 @@ public class T3Ui
     }
 
 
-    private void ToggleAllUiElements()
+    private static void ToggleAllUiElements()
     {
         //T3Ui.MaximalView = !T3Ui.MaximalView;
         if (UserSettings.Config.ShowToolbar)

--- a/Editor/Gui/T3UI.cs
+++ b/Editor/Gui/T3UI.cs
@@ -186,13 +186,7 @@ public class T3Ui
         }
         else if (KeyboardBinding.Triggered(UserActions.ToggleFocusMode))
         {
-            var shouldBeFocusMode = !UserSettings.Config.FocusMode;
-            UserSettings.Config.FocusMode = shouldBeFocusMode;
-            
-            UserSettings.Config.ShowToolbar = shouldBeFocusMode;
-            ToggleAllUiElements();
-            
-            LayoutHandling.LoadAndApplyLayoutOrFocusMode(shouldBeFocusMode ? 11 : UserSettings.Config.WindowLayoutIndex);
+            UserSettings.Config.FocusMode = !UserSettings.Config.FocusMode;
         }
     }
         
@@ -312,12 +306,6 @@ public class T3Ui
                 }
                     
                 ImGui.Separator();
-                ImGui.MenuItem("Full screen", KeyboardBinding.ListKeyboardShortcuts(UserActions.ToggleFullscreen, false), ref UserSettings.Config.FullScreen);
-
-                if (ImGui.MenuItem("Focus Mode", KeyboardBinding.ListKeyboardShortcuts(UserActions.ToggleFocusMode, false), ref UserSettings.Config.FocusMode))
-                {
-                    LayoutHandling.LoadAndApplyLayoutOrFocusMode(UserSettings.Config.WindowLayoutIndex);
-                }
                 if (ImGui.BeginMenu("Main Window Fullscreen Destination"))
                 {
                     for (var index = 0; index < EditorUi.AllScreens.Length; index++)
@@ -346,6 +334,9 @@ public class T3Ui
                     }
                     ImGui.EndMenu();
                 }
+
+                ImGui.MenuItem("Fullscreen", KeyboardBinding.ListKeyboardShortcuts(UserActions.ToggleFullscreen, false), ref UserSettings.Config.FullScreen);
+                ImGui.MenuItem("Focus Mode", KeyboardBinding.ListKeyboardShortcuts(UserActions.ToggleFocusMode, false), ref UserSettings.Config.FocusMode);
                 ImGui.EndMenu();
             }
                 

--- a/Editor/Gui/T3UI.cs
+++ b/Editor/Gui/T3UI.cs
@@ -318,6 +318,34 @@ public class T3Ui
                 {
                     LayoutHandling.LoadAndApplyLayoutOrFocusMode(UserSettings.Config.WindowLayoutIndex);
                 }
+                if (ImGui.BeginMenu("Main Window Fullscreen Destination"))
+                {
+                    for (var index = 0; index < EditorUi.AllScreens.Length; index++)
+                    {
+                        var screen = EditorUi.AllScreens.ElementAt(index);
+                        var label = $"{screen.DeviceName.Trim(new char[] { '\\', '.' })}" +
+                            $" ({screen.Bounds.Width}x{screen.Bounds.Height})";
+                        if(ImGui.MenuItem(label, "", index ==  UserSettings.Config.FullScreenIndexMain)) 
+                        {
+                            UserSettings.Config.FullScreenIndexMain = index;
+                        }
+                    }
+                    ImGui.EndMenu();
+                }
+                if(ImGui.BeginMenu("Viewer Window Fullscreen Destination"))
+                {
+                    for (var index = 0; index < EditorUi.AllScreens.Length; index++)
+                    {
+                        var screen = EditorUi.AllScreens.ElementAt(index);
+                        var label = $"{screen.DeviceName.Trim(new char[] { '\\', '.' })}" +
+                            $" ({screen.Bounds.Width}x{screen.Bounds.Height})";
+                        if(ImGui.MenuItem(label, "", index ==  UserSettings.Config.FullScreenIndexViewer)) 
+                        {
+                            UserSettings.Config.FullScreenIndexViewer = index;
+                        }
+                    }
+                    ImGui.EndMenu();
+                }
                 ImGui.EndMenu();
             }
                 

--- a/Editor/Gui/UiHelpers/UserSettings.cs
+++ b/Editor/Gui/UiHelpers/UserSettings.cs
@@ -78,7 +78,8 @@ namespace T3.Editor.Gui.UiHelpers
 
             // Other settings
             public float GizmoSize = 100;
-            public bool SwapMainAnd2ndWindowsWhenFullscreen = false;
+            public int FullScreenIndexMain = 0;
+            public int FullScreenIndexViewer = 0;
 
             // Timeline
             public float TimeRasterDensity = 1f;

--- a/Editor/Gui/Windows/SettingsWindow.cs
+++ b/Editor/Gui/Windows/SettingsWindow.cs
@@ -60,11 +60,6 @@ namespace T3.Editor.Gui.Windows
                                                                   "An experimental features that will drag neighbouring snapped operators.",
                                                                   UserSettings.Defaults.SmartGroupDragging);
                 
-                changed |= FormInputs.AddCheckBox("Fullscreen Window Swap",
-                                                                  ref UserSettings.Config.SwapMainAnd2ndWindowsWhenFullscreen,
-                                                                  "Swap main and second windows when fullscreen",
-                                                                  UserSettings.Defaults.SwapMainAnd2ndWindowsWhenFullscreen);
-                
                 changed |= FormInputs.AddCheckBox("Mousewheel adjust flight speed",
                                                   ref UserSettings.Config.AdjustCameraSpeedWithMouseWheel,
                                                   "If enabled, scrolling the mouse wheel while holding left of right mouse button will control navigation speed with WASD keys. This is similar to Unity and Unreal.",

--- a/Editor/SystemUi/EditorUi.cs
+++ b/Editor/SystemUi/EditorUi.cs
@@ -1,4 +1,5 @@
 using Microsoft.VisualBasic.ApplicationServices;
+using System.Windows.Forms;
 using T3.SystemUi;
 
 namespace T3.Editor.SystemUi;
@@ -16,5 +17,8 @@ internal static class EditorUi
             
             _instance = value;
         }
+    }
+    public static Screen[] AllScreens {
+        get => Screen.AllScreens;
     }
 }

--- a/Editor/UiContentUpdate.cs
+++ b/Editor/UiContentUpdate.cs
@@ -44,8 +44,6 @@ internal static class UiContentUpdate
         ImGui.GetIO().DisplaySize = ProgramWindows.Main.Size;
 
         ProgramWindows.HandleFullscreenToggle();
-        ProgramWindows.HandleFocusModeToggle();
-
         GraphOperations.UpdateChangedOperators();
 
         DirtyFlag.IncrementGlobalTicks();

--- a/Editor/UiContentUpdate.cs
+++ b/Editor/UiContentUpdate.cs
@@ -44,6 +44,8 @@ internal static class UiContentUpdate
         ImGui.GetIO().DisplaySize = ProgramWindows.Main.Size;
 
         ProgramWindows.HandleFullscreenToggle();
+        ProgramWindows.HandleFocusModeToggle();
+
         GraphOperations.UpdateChangedOperators();
 
         DirtyFlag.IncrementGlobalTicks();


### PR DESCRIPTION
- adds some index options to specify which monitor should show fullscreen windows
- remove the confusing "swap displays" toggle

- the 2 new options can be `Enums` too, thus a bit tricky to populate comfortably (advise if needed)
- should we re-address (basically toggle it off and on) the screen when setting is updated in order to update immediately ? or should this be a user action ?

<3