### PR TITLE
Symbol Change (right click->Change Symbol)

### DIFF
--- a/Editor/Gui/Graph/GraphCanvas.cs
+++ b/Editor/Gui/Graph/GraphCanvas.cs
@@ -828,6 +828,30 @@ namespace T3.Editor.Gui.Graph
             }
 
             ImGui.Separator();
+
+            if (ImGui.MenuItem("Change Symbol", someOpsSelected))
+            {
+                var startingSearchString = selectedChildUis[0].SymbolChild.Symbol.Name;
+                var position = selectedChildUis.Count == 1 ? selectedChildUis[0].PosOnCanvas : InverseTransformPositionFloat(ImGui.GetMousePos());
+                SymbolBrowser.OpenAt(position, null, null, false, startingSearchString, symbol =>
+                    {
+                        var nextSelection = new List<SymbolChild>();
+                        foreach (var sel in selectedChildUis)
+                        {
+                            var result = ChangeSymbol.ChangeOperatorSymbol(sel, symbol);
+                            if (result != null)
+                                nextSelection.Add(result);
+                        }
+                        NodeSelection.Clear();
+                        nextSelection.ForEach(symbolChild => {
+                                var childUi = SymbolUiRegistry.Entries[symbolChild.Parent.Id].ChildUis.SingleOrDefault(ui => ui.SymbolChild == symbolChild); // need better map?
+                                var instance = CompositionOp.Children.Single(c2 => c2.SymbolChildId == symbolChild.Id);
+                                if(childUi != null && instance != null)
+                                    NodeSelection.AddSymbolChildToSelection(childUi, instance); 
+                            });
+                    });
+            }
+
             if (ImGui.BeginMenu("Symbol definition..."))
             {
                 if (ImGui.MenuItem("Rename Symbol", oneOpSelected))

--- a/Editor/Gui/Graph/Interaction/SymbolBrowser.cs
+++ b/Editor/Gui/Graph/Interaction/SymbolBrowser.cs
@@ -27,15 +27,17 @@ namespace T3.Editor.Gui.Graph.Interaction
     public class SymbolBrowser
     {
         #region public API ------------------------------------------------------------------------
-        public void OpenAt(Vector2 positionOnCanvas, Type filterInputType, Type filterOutputType, bool onlyMultiInputs)
+
+        public void OpenAt(Vector2 positionOnCanvas, Type filterInputType, Type filterOutputType, bool onlyMultiInputs, string startingSearchString = "", System.Action<Symbol> overrideCreate = null)
         {
             //_prepareCommand = prepareCommand;
+            _overrideCreate = overrideCreate;
             IsOpen = true;
             PosOnCanvas = positionOnCanvas;
             _focusInputNextTime = true;
             _filter.FilterInputType = filterInputType;
             _filter.FilterOutputType = filterOutputType;
-            _filter.SearchString = "";
+            _filter.SearchString = startingSearchString;
             _selectedSymbolUi = null;
             _filter.OnlyMultiInputs = onlyMultiInputs;
             _filter.UpdateIfNecessary(forceUpdate: true);
@@ -130,6 +132,8 @@ namespace T3.Editor.Gui.Graph.Interaction
             ImGui.PopID();
         }
         #endregion
+
+        private System.Action<Symbol> _overrideCreate = null;
 
         //private bool IsSearchingPresets => _filter.MatchingPresets.Count > 0;
 
@@ -530,6 +534,13 @@ namespace T3.Editor.Gui.Graph.Interaction
 
         private void CreateInstance(Symbol symbol)
         {
+            if(_overrideCreate != null)
+            {
+                Close();
+                _overrideCreate(symbol);
+                return;
+            }
+
             var commandsForUndo = new List<ICommand>();
             var parent = GraphCanvas.Current.CompositionOp.Symbol;
 

--- a/Editor/Gui/Graph/Modification/ChangeSymbol.cs
+++ b/Editor/Gui/Graph/Modification/ChangeSymbol.cs
@@ -32,7 +32,7 @@ internal static class ChangeSymbol
         UndoRedoStack.AddAndExecute(moveCmd);
 
         // create new SymbolChild at original position
-        var addSymbolChildCommand = new AddSymbolChildCommand(symbolChild.Parent, newSymbol.Id) { PosOnCanvas = orgPos };
+        var addSymbolChildCommand = new AddSymbolChildCommand(symbolChild.Parent, newSymbol.Id) { PosOnCanvas = orgPos, ChildName = symbolChild.Name };
         UndoRedoStack.AddAndExecute(addSymbolChildCommand);
         var newSymbolChild = symbolChild.Parent.Children.Single(entry => entry.Id == addSymbolChildCommand.AddedChildId);
 

--- a/Editor/Gui/Graph/Modification/ChangeSymbol.cs
+++ b/Editor/Gui/Graph/Modification/ChangeSymbol.cs
@@ -1,0 +1,167 @@
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using Microsoft.CodeAnalysis;
+using T3.Core.Logging;
+using T3.Core.Operator;
+using T3.Editor.Gui.Commands;
+using T3.Editor.Gui.Selection;
+using T3.Editor.Gui.Commands.Graph;
+
+
+namespace T3.Editor.Gui.Graph.Modification;
+
+internal static class ChangeSymbol
+{
+    public static SymbolChild ChangeOperatorSymbol(SymbolChildUi symbolChildUi, Symbol newSymbol)
+    {
+        var symbolChild = symbolChildUi.SymbolChild;
+        if(symbolChild.Symbol == newSymbol)
+            return null;
+
+        var orgPos = symbolChildUi.PosOnCanvas;
+        var parentSymbolUi = SymbolUiRegistry.Entries[symbolChild.Parent.Id];
+
+        var conversionWasLossy = false;
+
+        // move old SymbolChild to new position
+        var moveCmd = new ModifyCanvasElementsCommand(parentSymbolUi, new List<ISelectableCanvasObject>() { symbolChildUi });
+        symbolChildUi.PosOnCanvas = orgPos + new Vector2(0, 100);
+        moveCmd.StoreCurrentValues();
+        UndoRedoStack.AddAndExecute(moveCmd);
+
+        // create new SymbolChild at original position
+        var addSymbolChildCommand = new AddSymbolChildCommand(symbolChild.Parent, newSymbol.Id) { PosOnCanvas = orgPos };
+        UndoRedoStack.AddAndExecute(addSymbolChildCommand);
+        var newSymbolChild = symbolChild.Parent.Children.Single(entry => entry.Id == addSymbolChildCommand.AddedChildId);
+
+        // loop though inputs
+        foreach (var input in symbolChild.Inputs)
+        {
+            var connections = symbolChild.Parent.Connections.FindAll(c => c.TargetSlotId == input.Key
+                                                                    && c.TargetParentOrChildId == symbolChild.Id);
+
+            var inputName = input.Value.Name;
+            var destInput = newSymbolChild.Inputs.FirstOrDefault(x => x.Value.Name == inputName);
+
+            if (connections.Count > 1) // can this happen?
+            {
+                Log.Warning("\"Change Symbol...\" : connections.Count > 1 : not yet implemented, skipping!");
+                System.Diagnostics.Debug.Assert(false);
+            }
+            else 
+            {
+                var inputHasData = connections.Count > 0 || !input.Value.IsDefault;
+
+                if (destInput.Value != null)
+                {
+                    if(input.Value.Value.ValueType == destInput.Value.Value.ValueType)
+                    {
+                        // treating default value as a special assignment,
+                        // this is also how it is indicated in the UI.
+                        // Just leave the initial value of newSymbol input
+                        // (assuming this is same as default)
+
+                        if (!input.Value.IsDefault) 
+                        {
+                            var changeValCommand = new ChangeInputValueCommand(symbolChild.Parent, newSymbolChild.Id, destInput.Value, input.Value.Value);
+                            UndoRedoStack.AddAndExecute(changeValCommand);
+                        }
+
+                        if (connections.Count == 1)
+                        {
+                            // remove old connection to symbolChild
+
+                            var delCommand = new DeleteConnectionCommand(symbolChild.Parent, connections[0], 0);
+                            UndoRedoStack.AddAndExecute(delCommand);
+
+
+                            // add new connection to newSymbolChild
+
+                            var newConnectionToInput = new Symbol.Connection(
+                                                    sourceParentOrChildId: connections[0].SourceParentOrChildId,
+                                                    sourceSlotId: connections[0].SourceSlotId,
+                                                    targetParentOrChildId: newSymbolChild.Id,
+                                                    targetSlotId: destInput.Key);
+                            var addCommand = new AddConnectionCommand(symbolChild.Parent, newConnectionToInput, 0);
+                            UndoRedoStack.AddAndExecute(addCommand);
+                        }
+                    }
+                    else if(inputHasData)
+                    {
+                        conversionWasLossy = true;
+                        Log.Info("\"Change Symbol...\" : type mismatching, input:" + inputName + ", " + input.Value.Value.ValueType + "(old) vs " + destInput.Value.Value.ValueType + "(new)");
+                    }
+
+                }
+                else if(inputHasData)
+                {
+                    conversionWasLossy = true;
+                    Log.Info("\"Change Symbol...\" : no matching input, name: " + inputName);
+                }
+
+            }
+
+        }
+
+
+        // loop though outputs
+        foreach (var output in symbolChild.Outputs)
+        {
+            var connections = symbolChild.Parent.Connections.FindAll(c => c.SourceSlotId == output.Key
+                                                                    && c.SourceParentOrChildId == symbolChild.Id);
+
+            var outputName = output.Value.OutputDefinition.Name;
+            var destOutput = newSymbolChild.Outputs.FirstOrDefault(x => x.Value.OutputDefinition.Name == outputName);
+
+            foreach (var connection in connections)
+            {
+                if (destOutput.Value != null)
+                {
+                    if (output.Value.OutputDefinition.ValueType == destOutput.Value.OutputDefinition.ValueType)
+                    {
+                        // remove old connection from symbolChild
+
+                        var multiInputIndex = symbolChild.Parent.GetMultiInputIndexFor(connection);
+                        var delCommand = new DeleteConnectionCommand(symbolChild.Parent, connection, multiInputIndex);
+                        UndoRedoStack.AddAndExecute(delCommand);
+
+
+                        // add new connection from newSymbolChild
+
+                        var newConnectionToInput = new Symbol.Connection(
+                                             sourceParentOrChildId: newSymbolChild.Id,
+                                             sourceSlotId: destOutput.Key,
+                                             targetParentOrChildId: connection.TargetParentOrChildId,
+                                             targetSlotId: connection.TargetSlotId);
+                        var addCommand = new AddConnectionCommand(symbolChild.Parent, newConnectionToInput, multiInputIndex);
+                        UndoRedoStack.AddAndExecute(addCommand);
+                    }
+                    else
+                    {
+                        conversionWasLossy = true;
+                        Log.Info("\"Change Symbol...\" : type mismatching, input:" + outputName + ", " + output.Value.OutputDefinition.ValueType + "(old) vs " + destOutput.Value.OutputDefinition.ValueType + "(new)");
+                    }
+                }
+                else
+                {
+                    conversionWasLossy = true;
+                    Log.Info("\"Change Symbol...\" : no matching output, name: " + outputName + " (connection left as is)");
+                }
+            }
+        }
+
+        if(!conversionWasLossy)
+        {
+            var delCommand = new DeleteSymbolChildrenCommand(parentSymbolUi, new List<SymbolChildUi>() { symbolChildUi });
+            UndoRedoStack.AddAndExecute(delCommand);
+        }
+        else
+        {
+            Log.Warning("\"Change Symbol...\" : old operator not deleted due to lossy conversion");
+        }
+
+        return newSymbolChild;
+    }
+}


### PR DESCRIPTION
Implementation info, steps (for each selected SymbolChild):
(1) Create a new SymbolChild
(2) Loop through in/out and match connections/data by name and type and copy/connect to newly created
(3) If conversion was lossless, remove original SymbolChild
(4) Select new SymbolChild

For UI, I modified the SymbolBrowser to be able to return the target Symbol in a callback instead of creating it directly

Reason for this PR:
I felt it was slow and error prone to manually reproduce properties and connections when switching between different versions or implementations of operators (for instance when using "Duplicate as new type..." to edit a built-in operator)

(I have almost no experience with the codebase so I probably missed some stuff, or messed up some stuff!)