### PR TITLE
fix: rework of the 'i know what i'm doing' pop-up

### DIFF
--- a/Editor/Gui/Graph/Dialogs/LibWarningDialog.cs
+++ b/Editor/Gui/Graph/Dialogs/LibWarningDialog.cs
@@ -1,4 +1,6 @@
 ﻿using ImGuiNET;
+using T3.Core.Operator;
+using T3.Editor.Gui.Styling;
 using T3.Editor.Gui.UiHelpers;
 
 namespace T3.Editor.Gui.Graph.Dialogs
@@ -9,27 +11,47 @@ namespace T3.Editor.Gui.Graph.Dialogs
         {
             if (BeginDialog("Careful now"))
             {
-                ImGui.TextUnformatted($"You tried to open a library symbol.\nAny change would affect {DependencyCount} operators using it.");
+                ImGui.TextUnformatted("You tried to open a library symbol.\n" +
+                    $"Any change would affect {DependencyCount} operators using it.");
                 ImGui.Spacing();
                 
                 
                 if (ImGui.Button("Cancel"))
                 {
                     ImGui.CloseCurrentPopup();
+                    // the UserSettings modification get rolled-back when the user hits cancel:
+                    // we can safely assume it was true before (since the pop-up was displayed)
+                    UserSettings.Config.WarnBeforeLibEdit = true;
                 }
 
                 ImGui.SameLine();
                 if (ImGui.Button("I know what I'm doing"))
                 {
-                    UserSettings.Config.WarnBeforeLibEdit = false;
+                    GraphCanvas.Current.SetCompositionToChildInstance(HandledInstance);
                     ImGui.CloseCurrentPopup();
+
                 }
 
+                // no sane way to "mirror" a ref, note: this whole section could be replaced
+                // by a simple UserSettings reference, and changing label to "Remind me next time"
+                // "Dont ask again" is actually the better/safer mainly bc it's the label we're all used to.
+                if(ImGui.TreeNode("More..."))
+                {
+                    var DontWarnAgain = !UserSettings.Config.WarnBeforeLibEdit;
+                    FormInputs.SetIndent(10);
+                    if(FormInputs.AddCheckBox("Don't ask me again!", ref DontWarnAgain))
+                    {
+                        DontWarnAgain = !DontWarnAgain;
+                        UserSettings.Config.WarnBeforeLibEdit = !UserSettings.Config.WarnBeforeLibEdit;
+                    }
+                }
                 EndDialogContent();
+                ImGui.TreePop();
             }
             EndDialog();
         }
 
         public static int DependencyCount=0;
+        public static Instance HandledInstance;
     }
 }

--- a/Editor/Gui/Graph/GraphNode.cs
+++ b/Editor/Gui/Graph/GraphNode.cs
@@ -259,6 +259,7 @@ namespace T3.Editor.Gui.Graph
                                 {
                                     var count = Structure.CollectDependingSymbols(instance.Symbol).Count();
                                     LibWarningDialog.DependencyCount = count;
+                                    LibWarningDialog.HandledInstance = instance;
                                     GraphCanvas.LibWarningDialog.ShowNextFrame();
                                     blocked = true;
                                 }


### PR DESCRIPTION
This solve #288 

- we get inside child upon clicking the button (you had to double click the op again before)
- "don't ask again" now correctly reflect and update the Warn setting...
- ... and can be canceled too (the settings is discarded then)
- cosmetics