### PR TITLE
Fix T3 crash if Copy an empty Console

### DIFF
--- a/Editor/Gui/Windows/ConsoleLogWindow.cs
+++ b/Editor/Gui/Windows/ConsoleLogWindow.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
@@ -43,6 +43,7 @@ namespace T3.Editor.Gui.Windows
                 {
                     _logEntries.Clear();
                 }
+                Log.Info("Console cleared!");
             }
 
             ImGui.SameLine();


### PR DESCRIPTION
If you hit the Console's Clear button then hit Copy button T3 will crash. Fixed by adding a "Console cleared" log entry.
