### PR TITLE
Lock Output Canvas in place

### DIFF
--- a/Editor/Gui/UiHelpers/UserSettings.cs
+++ b/Editor/Gui/UiHelpers/UserSettings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -63,7 +63,9 @@ namespace T3.Editor.Gui.UiHelpers
             public float CameraSpeed = 1;
 
             public TimeLineCanvas.FrameStepAmount FrameStepAmount = TimeLineCanvas.FrameStepAmount.FrameAt30Fps;
-            
+
+            public bool LockOutputCanvas = false;
+
             public bool MouseWheelEditsNeedCtrlKey = true;
             public bool AutoPinAllAnimations = false;
 

--- a/Editor/Gui/Windows/ImageOutputCanvas.cs
+++ b/Editor/Gui/Windows/ImageOutputCanvas.cs
@@ -15,9 +15,15 @@ namespace T3.Editor.Gui.Windows
     {
         public void Update()
         {
-            
-            UpdateCanvas();
-            UpdateViewMode();
+            if (!UserSettings.Config.LockOutputCanvas)
+            {
+                UpdateCanvas();
+                UpdateViewMode();
+            }
+            else
+            {
+                UpdateCanvas();
+            } 
             
         }
 

--- a/Editor/Gui/Windows/SettingsWindow.cs
+++ b/Editor/Gui/Windows/SettingsWindow.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Numerics;
 using ImGuiNET;
 using Operators.Utils;
@@ -63,6 +63,11 @@ namespace T3.Editor.Gui.Windows
                                                   ref UserSettings.Config.MouseWheelEditsNeedCtrlKey,
                                                   "In parameter window you can edit numeric values by using the mouse wheel. This setting will prevent accidental modifications while scrolling because by using ctrl key for activation.",
                                                   UserSettings.Defaults.MouseWheelEditsNeedCtrlKey);
+
+                changed |= FormInputs.AddCheckBox("Lock Output canvas",
+                                                  ref UserSettings.Config.LockOutputCanvas,
+                                                  "In output window you can scroll and scale the canvas. This setting will disable this feature.",
+                                                  UserSettings.Defaults.LockOutputCanvas);
 
                 FormInputs.ResetIndent();
                 FormInputs.AddVerticalSpace();


### PR DESCRIPTION
A user setting to avoid moving and scaling the Output canvas