### PR TITLE
Fix documentation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ We hope to bring together a community of artists, developers and creative tinker
 Please follow the [installation guide](https://github.com/tooll3/t3/wiki/Installation).
 
 ## Get Help
-To get started read the [documentation](https://github.com/tooll3/t3/wiki/user-interface) or watch [tutorial videos](https://www.youtube.com/watch?v=eH2E02U6P5Q&list=PLj-rnPROvbn3LigXGRSDvmLtgTwmNHcQs&index=4)
+To get started read the [documentation](https://github.com/tooll3/t3/wiki) or watch [tutorial videos](https://www.youtube.com/watch?v=eH2E02U6P5Q&list=PLj-rnPROvbn3LigXGRSDvmLtgTwmNHcQs&index=4).
 
-If you have questions or feedback, please join us on discord: https://discord.gg/YmSyQdeH3S 
+If you have questions or feedback, please join us on Discord: https://discord.gg/YmSyQdeH3S 
 
 
 


### PR DESCRIPTION
Changing README.md from a test link to the documentation homepage and capitalising 'Discord'. Minor edit to README no change to source.

Closes #317 