### PR TITLE
Filling the gap

### DIFF
--- a/Core/Audio/AudioEngine.cs
+++ b/Core/Audio/AudioEngine.cs
@@ -111,7 +111,7 @@ namespace T3.Core.Audio
         
         private static void UpdateFftBuffer(int soundStreamHandle, Playback playback)
         {
-            const int get256FftValues = (int)DataFlags.FFT512;
+            const int get256FftValues = (int)DataFlags.FFT2048;
             
             if (playback.Settings != null && playback.Settings.AudioSource == PlaybackSettings.AudioSources.ProjectSoundTrack)
             {


### PR DESCRIPTION
While I was trying to understand how audio is handled in order to separate Left and Right channels. (Fail) 
I found how to get consistency between the audio analysis from external device and the Soundtrack 

![image](https://github.com/tooll3/t3/assets/3755089/c949fc4b-3410-4ff9-b45a-272fbca58826)
