### PR TITLE
fix typo mesh-TransformVertices.hlsl

### DIFF
--- a/Resources/lib/3d/mesh/mesh-TransformVertices.hlsl
+++ b/Resources/lib/3d/mesh/mesh-TransformVertices.hlsl
@@ -29,8 +29,8 @@ void main(uint3 i : SV_DispatchThreadID)
     float3 normal = SourceVerts[i.x].Normal;
     ResultVerts[i.x].Normal = lerp(normal,normalize(mul(float4(normal,0), TransformMatrix).xyz), s);
 
-    float3 tangent =SourceVerts[i.x].Tangent;
-    ResultVerts[i.x].Tangent = lerp(normal,normalize(mul(float4(tangent,0), TransformMatrix).xyz), s);
+    float3 tangent = SourceVerts[i.x].Tangent;
+    ResultVerts[i.x].Tangent = lerp(tangent,normalize(mul(float4(tangent,0), TransformMatrix).xyz), s);
 
     float3 bitangent = SourceVerts[i.x].Bitangent;
     ResultVerts[i.x].Bitangent = lerp(bitangent, normalize(mul(float4(bitangent,0), TransformMatrix).xyz), s);


### PR DESCRIPTION
The shader `mesh-TransformVertices.hlsl` seems to have a typo