### PR TITLE
Add a folder to userSettings for image sequence render

### DIFF
--- a/Editor/Gui/UiHelpers/UserSettings.cs
+++ b/Editor/Gui/UiHelpers/UserSettings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -98,8 +98,8 @@ namespace T3.Editor.Gui.UiHelpers
 
             // Rendering (controlled from render windows)
             public string RenderVideoFilePath = "./Render/render-v01.mp4";
+            public string RenderSequenceFilePath = "./ImageSequence/";
 
-            
             [JsonConverter(typeof(StringEnumConverter))]
             public TimeFormat.TimeDisplayModes TimeDisplayMode = TimeFormat.TimeDisplayModes.Bars;
             

--- a/Editor/Gui/Windows/RenderExport/RenderSequenceWindow.cs
+++ b/Editor/Gui/Windows/RenderExport/RenderSequenceWindow.cs
@@ -125,7 +125,7 @@ public class RenderSequenceWindow : BaseRenderWindow
     private static string Extension => _fileFormat.ToString().ToLower(); 
 
     private static double _exportStartedTime;
-    private static string _targetFolder = "./Render";
+    private static string _targetFolder = UserSettings.Config.RenderSequenceFilePath;
 
     private static ScreenshotWriter.FileFormats _fileFormat;
     private static string _lastHelpString = string.Empty;


### PR DESCRIPTION
Same behavior as the Video render window.
It will create a default folder to render image sequence if the user didn't select a folder.
If the user select an other folder to render image sequences, T3 will remember it.
