### PR TITLE
Bring back FFT2048

### DIFF
--- a/Core/Audio/AudioEngine.cs
+++ b/Core/Audio/AudioEngine.cs
@@ -264,7 +264,7 @@ namespace T3.Core.Audio
 
         private static void UpdateFftBuffer(int soundStreamHandle, Playback playback)
         {
-            int get256FftValues = (int)DataFlags.FFT512;
+            int get256FftValues = (int)DataFlags.FFT2048;
 
             // do not advance plaback if we are not in live mode
             if (!playback.IsLive)


### PR DESCRIPTION
After the commit to add audio to video export, FFT2048 was set back to FFT512