### PR TITLE
PairPointsForSpline: Fix points orientation

### DIFF
--- a/Resources/lib/points/combine/PairPointsForSplines.hlsl
+++ b/Resources/lib/points/combine/PairPointsForSplines.hlsl
@@ -16,9 +16,12 @@ cbuffer Params : register(b0)
     float Debug;
 }
 
+
+
 StructuredBuffer<Point> PointsA : t0;        // input
 StructuredBuffer<Point> PointsB : t1;        // input
 RWStructuredBuffer<Point> ResultPoints : u0; // output
+
 
 inline float3 Interpolate(float t, float3 pA, float3 tA, float3 tB, float3 pB) 
 {
@@ -26,14 +29,12 @@ inline float3 Interpolate(float t, float3 pA, float3 tA, float3 tB, float3 pB)
     float t3 = t2 * t;
 
     return (2 * t3 - 3 * t2 + 1) * pA +
-                (t3 - 2 * t2 + t) * tA +
-                (-2 * t3 + 3 * t2) * pB +
-                (t3 - t2) * -tB;
+           (t3 - 2 * t2 + t) * tA +
+           (-2 * t3 + 3 * t2) * pB +
+           (t3 - t2) * -tB;
 }
 
-
-[numthreads(64, 1, 1)] void main(uint3 i
-                                 : SV_DispatchThreadID)
+[numthreads(64, 1, 1)] void main(uint3 i : SV_DispatchThreadID)
 {
     uint resultCount, countA, countB, stride;
     ResultPoints.GetDimensions(resultCount, stride);
@@ -46,37 +47,44 @@ inline float3 Interpolate(float t, float3 pA, float3 tA, float3 tB, float3 pB)
 
     uint pairIndex = i.x / pointsPerSegment;
     uint indexInLine = i.x % pointsPerSegment;
-    float f = (float)indexInLine / (float)(pointsPerSegment - 2);
+    float f = (float)indexInLine / (float)(pointsPerSegment - 2); 
 
-    if (indexInLine == pointsPerSegment - 1)
+     if (indexInLine == pointsPerSegment - 1)
     {
         ResultPoints[i.x].W = sqrt(-1); // NaN for divider
         return;
     }
 
-    uint indexA = pairIndex % countA;
-    uint indexB = pairIndex % countB;
+    uint indexA = pairIndex / countA;
+    uint indexB = pairIndex / countB;
 
     float3 posA1 = PointsA[indexA].Position;
     float3 posB1 = PointsB[indexB].Position;
     float3 forward = TangentDirection;
 
     float paW = PointsA[indexA].W;
-    float pbW = PointsA[indexB].W;
+    float pbW = PointsB[indexB].W;
     float3 tA = qRotateVec3(forward, PointsA[indexA].Rotation) * (TangentA + paW * TangentA_WFactor);
     float3 tB = qRotateVec3(forward, PointsB[indexB].Rotation) * (TangentB + pbW * TangentB_WFactor);
 
     float3 pF = Interpolate(f, posA1, tA, tB, posB1);
     ResultPoints[i.x].Position = pF;
-    ResultPoints[i.x].Color = lerp(PointsA[indexA].Color, PointsA[indexA].Color, f);
-    ResultPoints[i.x].Stretch = lerp(PointsA[indexA].Stretch, PointsA[indexA].Stretch, f);
+    ResultPoints[i.x].Color = lerp(PointsA[indexA].Color, PointsB[indexB].Color, f);
+    ResultPoints[i.x].Stretch = lerp(PointsA[indexA].Stretch, PointsB[indexB].Stretch, f);
 
-    float3 pF2 = Interpolate(f+0.001, posA1, tA, tB, posB1);
-    float3 forward2= normalize(pF-pF2);
-    float3 up = float3(0,0,1);
-    float fade = 1-abs(dot(up,forward2));
+    float3 pF2 = Interpolate(f + 0.001, posA1, tA, tB, posB1); // Adjusted increment for finite difference
+    float3 forward2 = normalize(pF2 - pF);
+    float3 up = float3(0, 0, 1);
+    float fade = 1 - abs(dot(up, forward2));
     float3 refUp = lerp(tA, tB, f);
-    ResultPoints[i.x].Rotation =  qLookAt(forward2, refUp);
-    float w = isnan(paW) || isnan(paW) ? NAN : lerp(PointsA[indexA].W, PointsA[indexA].W, f);;
+    ResultPoints[i.x].Rotation = qLookAt(forward2, refUp);
+
+    // Ugly fix for the last point's orientation, but it works 
+    int fixPpoint = segmentCount-2;
+    ResultPoints[fixPpoint.x].Rotation *= float4(1,-1,-1,1);
+    
+
+    // Handle NaN values correctly
+    float w = isnan(paW) || isnan(pbW) ? NAN : lerp(PointsA[indexA].W, PointsB[indexB].W, f);
     ResultPoints[i.x].W = InitWTo01 > 0.5 ? f : w;
 }


### PR DESCRIPTION
The issue is noticeable when used with [ExtrudeCurves] : normals are flipped and the last point is also flipped. 
![image](https://github.com/tooll3/t3/assets/3755089/2a66efc4-e3ef-4267-a38e-4f9152d701f3)

After the fix : it's working in this specific case but the last point orientation remains if we use other sources of points like [SpherePoints] or [RadialPoints] 
![image](https://github.com/tooll3/t3/assets/3755089/089bad1a-25f2-42dd-8641-a724bc13eaf9)

