### PR TITLE
feat: add an OscOutput operator and its example

### DIFF
--- a/Operators/Types/lib/io/osc/OscInput.cs
+++ b/Operators/Types/lib/io/osc/OscInput.cs
@@ -24,21 +24,16 @@ namespace T3.Operators.Types.Id_3a1d7ea0_5445_4df0_b08a_6596e53f815a
         [Output(Guid = "8F426B4A-AD49-4AB9-80EE-3DF9F5A5AFF6", DirtyFlagTrigger = DirtyFlagTrigger.Animated)]
         public readonly Slot<float> LastMessageTime = new ();
 
-        [Output(Guid = "004c2d30-a709-4f21-af5d-0377f93dcd16")]
-        public readonly Slot<string> TextResult = new();
-
         public OscInput()
         {
             FirstResult.UpdateAction = Update;
             Results.UpdateAction = Update;
             LastMessageTime.UpdateAction = Update;
-            TextResult.UpdateAction = Update;
         }
 
         private void Update(EvaluationContext context)
         {
             _address = Address.GetValue(context);
-            _textMode = TextMode.GetValue(context);
             
             var newPort = Port.GetValue(context);
             if (newPort != _registeredPort)
@@ -110,7 +105,6 @@ namespace T3.Operators.Types.Id_3a1d7ea0_5445_4df0_b08a_6596e53f815a
                     
                     _lastMessageTime = Playback.RunTimeInSecs;
                     _isDefaultValue = false;
-                    _textOut = (string)message[0];
                 }
 
                 _lastMatchingSignals.Clear();
@@ -124,8 +118,6 @@ namespace T3.Operators.Types.Id_3a1d7ea0_5445_4df0_b08a_6596e53f815a
 
         private double _lastMessageTime;
         private List<float> _allResults = new();
-        private bool _textMode;
-        private string _textOut;
 
         // Called in other thread!
         public void ProcessMessage(OscMessage msg)
@@ -144,8 +136,6 @@ namespace T3.Operators.Types.Id_3a1d7ea0_5445_4df0_b08a_6596e53f815a
                     _lastMatchingSignals.Add(msg);
                     _isDefaultValue = false;
                 }
-
-                if (_textMode) TextResult.Value = (string)msg[0];
             }
         }
 

--- a/Operators/Types/lib/io/osc/OscInput.cs
+++ b/Operators/Types/lib/io/osc/OscInput.cs
@@ -24,17 +24,21 @@ namespace T3.Operators.Types.Id_3a1d7ea0_5445_4df0_b08a_6596e53f815a
         [Output(Guid = "8F426B4A-AD49-4AB9-80EE-3DF9F5A5AFF6", DirtyFlagTrigger = DirtyFlagTrigger.Animated)]
         public readonly Slot<float> LastMessageTime = new ();
 
+        [Output(Guid = "004c2d30-a709-4f21-af5d-0377f93dcd16")]
+        public readonly Slot<string> TextResult = new();
 
         public OscInput()
         {
             FirstResult.UpdateAction = Update;
             Results.UpdateAction = Update;
             LastMessageTime.UpdateAction = Update;
+            TextResult.UpdateAction = Update;
         }
 
         private void Update(EvaluationContext context)
         {
             _address = Address.GetValue(context);
+            _textMode = TextMode.GetValue(context);
             
             var newPort = Port.GetValue(context);
             if (newPort != _registeredPort)
@@ -106,6 +110,7 @@ namespace T3.Operators.Types.Id_3a1d7ea0_5445_4df0_b08a_6596e53f815a
                     
                     _lastMessageTime = Playback.RunTimeInSecs;
                     _isDefaultValue = false;
+                    _textOut = (string)message[0];
                 }
 
                 _lastMatchingSignals.Clear();
@@ -119,6 +124,8 @@ namespace T3.Operators.Types.Id_3a1d7ea0_5445_4df0_b08a_6596e53f815a
 
         private double _lastMessageTime;
         private List<float> _allResults = new();
+        private bool _textMode;
+        private string _textOut;
 
         // Called in other thread!
         public void ProcessMessage(OscMessage msg)
@@ -132,11 +139,13 @@ namespace T3.Operators.Types.Id_3a1d7ea0_5445_4df0_b08a_6596e53f815a
 
                 var matchesAddress = msg.Address == _address;
 
-                    if (matchesAddress || _teachingActive)
-                    {
-                        _lastMatchingSignals.Add(msg);
-                        _isDefaultValue = false;
+                if (matchesAddress || _teachingActive)
+                {
+                    _lastMatchingSignals.Add(msg);
+                    _isDefaultValue = false;
                 }
+
+                if (_textMode) TextResult.Value = (string)msg[0];
             }
         }
 
@@ -174,9 +183,8 @@ namespace T3.Operators.Types.Id_3a1d7ea0_5445_4df0_b08a_6596e53f815a
 
         [Input(Guid = "6C15E743-9A70-47E7-A0A4-75636817E441")]
         public readonly InputSlot<bool> PrintLogMessages = new();
-        
-        
-        
 
+        [Input(Guid = "dbd5e806-faa7-4cc0-b997-f00041fe1fd1")]
+        public readonly InputSlot<bool> TextMode = new InputSlot<bool>();
     }
 }

--- a/Operators/Types/lib/io/osc/OscInput.cs
+++ b/Operators/Types/lib/io/osc/OscInput.cs
@@ -173,8 +173,5 @@ namespace T3.Operators.Types.Id_3a1d7ea0_5445_4df0_b08a_6596e53f815a
 
         [Input(Guid = "6C15E743-9A70-47E7-A0A4-75636817E441")]
         public readonly InputSlot<bool> PrintLogMessages = new();
-
-        [Input(Guid = "dbd5e806-faa7-4cc0-b997-f00041fe1fd1")]
-        public readonly InputSlot<bool> TextMode = new InputSlot<bool>();
     }
 }

--- a/Operators/Types/lib/io/osc/OscOutput.cs
+++ b/Operators/Types/lib/io/osc/OscOutput.cs
@@ -11,28 +11,42 @@ namespace T3.Operators.Types.Id_4e99da86_482f_4037_8664_b2371526d632
 {
     public class OscOutput : Instance<OscOutput>
     {
-        private bool _connected;
-        private IPAddress _address;
-        private int _port;
-        private float _num_value;
-        private string _str_value;
-        private OscSender _sender;
+        [Input(Guid = "98f38caa-4f79-425c-ab46-22d7dbe62978")]
+        public readonly InputSlot<string> IpAddress = new InputSlot<string>();
+
+        [Input(Guid = "6c0e07ba-7ea6-4dab-af0b-61cf9cb74ad7")]
+        public readonly InputSlot<int> Port = new InputSlot<int>();
+
+        [Input(Guid = "9016e418-7761-4916-aafb-c95599f77f38")]
+        public readonly InputSlot<string> Location = new InputSlot<string>();
+
+        [Input(Guid = "d5e9e9be-093b-4d57-9070-9b2cf33aa45b")]
+        public readonly InputSlot<string> String = new InputSlot<string>();
+
+        [Input(Guid = "827c7ae2-c129-4d04-a715-328c0a86bf8a")]
+        public readonly InputSlot<float> Number = new InputSlot<float>();
+
+        [Input(Guid = "4931217b-e30d-42a6-9cda-bc49a8fd8d67", MappedType = typeof(OscTypes))]
+        public readonly InputSlot<int> OscValueType = new ();
+
+        [Output(Guid = "a6679d6c-fc34-4588-ab20-5079ad8f8a03")]
         public OscOutput()
         {
             Result.UpdateAction = Update;
         }
 
-        private enum OscType
+        private enum OscTypes
         {
             Number,
             String
         }
+
         private void Update(EvaluationContext context)
         {
             var location = Location.GetValue(context);
             var num = Number.GetValue(context);
             var str = String.GetValue(context);
-            var oscType = OscValueType.GetEnumValue<OscType>(context);
+            var oscType = OscValueType.GetEnumValue<OscTypes>(context);
 
             CheckAddr(context);
             if (OscAddress.IsValidAddressPattern(location) == false)
@@ -42,7 +56,7 @@ namespace T3.Operators.Types.Id_4e99da86_482f_4037_8664_b2371526d632
             }
             switch (oscType)
             {
-                case OscType.Number:
+                case OscTypes.Number:
                     if (num != _num_value)
                     {
                         // Log.Info("Sending:" + num);
@@ -52,11 +66,11 @@ namespace T3.Operators.Types.Id_4e99da86_482f_4037_8664_b2371526d632
                             _sender.Send(message);
                             _num_value = num;
                         }
-                        else Log.Error("failed to build the OSC message (float): " + message.ErrorMessage);
+                        else Log.Error("Failed to build the OSC message (float): " + message.ErrorMessage);
                     }
                     break;
 
-                case OscType.String:
+                case OscTypes.String:
                     if (str != _str_value)
                     {
                         // Log.Info("Sending:" + str);
@@ -66,7 +80,7 @@ namespace T3.Operators.Types.Id_4e99da86_482f_4037_8664_b2371526d632
                             _sender.Send(message);
                             _str_value = str;
                         }
-                        else Log.Error("failed to build the OSC message (string): " + message.ErrorMessage);
+                        else Log.Error("Failed to build the OSC message (string): " + message.ErrorMessage);
                     }
                     break;
             }
@@ -77,7 +91,7 @@ namespace T3.Operators.Types.Id_4e99da86_482f_4037_8664_b2371526d632
             IPAddress address;
             try
             {
-                address = IPAddress.Parse(Address.GetValue(context));
+                address = IPAddress.Parse(IpAddress.GetValue(context));
             }
             catch (System.FormatException e)
             {
@@ -117,26 +131,12 @@ namespace T3.Operators.Types.Id_4e99da86_482f_4037_8664_b2371526d632
             _connected = false;
         }
 
-        [Input(Guid = "98f38caa-4f79-425c-ab46-22d7dbe62978")]
-        public readonly InputSlot<string> Address = new InputSlot<string>();
-
-        [Input(Guid = "6c0e07ba-7ea6-4dab-af0b-61cf9cb74ad7")]
-        public readonly InputSlot<int> Port = new InputSlot<int>();
-
-
-        [Input(Guid = "9016e418-7761-4916-aafb-c95599f77f38")]
-        public readonly InputSlot<string> Location = new InputSlot<string>();
-
-        [Input(Guid = "d5e9e9be-093b-4d57-9070-9b2cf33aa45b")]
-        public readonly InputSlot<string> String = new InputSlot<string>();
-
-        [Input(Guid = "827c7ae2-c129-4d04-a715-328c0a86bf8a")]
-        public readonly InputSlot<float> Number = new InputSlot<float>();
-
-        [Input(Guid = "4931217b-e30d-42a6-9cda-bc49a8fd8d67", MappedType = typeof(OscType))]
-        public readonly InputSlot<int> OscValueType = new ();
-
-        [Output(Guid = "a6679d6c-fc34-4588-ab20-5079ad8f8a03")]
         public readonly Slot<T3.Core.DataTypes.Command> Result = new Slot<T3.Core.DataTypes.Command>();
+        private bool _connected;
+        private IPAddress _address;
+        private int _port;
+        private float _num_value;
+        private string _str_value;
+        private OscSender _sender;
     }
 }

--- a/Operators/Types/lib/io/osc/OscOutput.cs
+++ b/Operators/Types/lib/io/osc/OscOutput.cs
@@ -1,0 +1,142 @@
+using T3.Core.Operator;
+using T3.Core.Operator.Attributes;
+using T3.Core.Operator.Slots;
+using T3.Core.Logging;
+using System.Net;
+using Rug.Osc;
+using System;
+using T3.Core.Utils;
+
+namespace T3.Operators.Types.Id_4e99da86_482f_4037_8664_b2371526d632
+{
+    public class OscOutput : Instance<OscOutput>
+    {
+        private bool _connected;
+        private IPAddress _address;
+        private int _port;
+        private float _num_value;
+        private string _str_value;
+        private OscSender _sender;
+        public OscOutput()
+        {
+            Result.UpdateAction = Update;
+        }
+
+        private enum OscType
+        {
+            Number,
+            String
+        }
+        private void Update(EvaluationContext context)
+        {
+            var location = Location.GetValue(context);
+            var num = Number.GetValue(context);
+            var str = String.GetValue(context);
+            var oscType = OscValueType.GetEnumValue<OscType>(context);
+
+            CheckAddr(context);
+            if (OscAddress.IsValidAddressPattern(location) == false)
+            {
+                Log.Error("OSC location is invalid");
+                return;
+            }
+            switch (oscType)
+            {
+                case OscType.Number:
+                    if (num != _num_value)
+                    {
+                        // Log.Info("Sending:" + num);
+                        OscMessage message = new OscMessage(location, num);
+                        if (message.Error == OscPacketError.None)
+                        {
+                            _sender.Send(message);
+                            _num_value = num;
+                        }
+                        else Log.Error("failed to build the OSC message (float): " + message.ErrorMessage);
+                    }
+                    break;
+
+                case OscType.String:
+                    if (str != _str_value)
+                    {
+                        // Log.Info("Sending:" + str);
+                        OscMessage message = new OscMessage(location, str);
+                        if (message.Error == OscPacketError.None)
+                        {
+                            _sender.Send(message);
+                            _str_value = str;
+                        }
+                        else Log.Error("failed to build the OSC message (string): " + message.ErrorMessage);
+                    }
+                    break;
+            }
+        }
+
+        private void CheckAddr(EvaluationContext context)
+        {
+            IPAddress address;
+            try
+            {
+                address = IPAddress.Parse(Address.GetValue(context));
+            }
+            catch (System.FormatException e)
+            {
+                Log.Error("Failed to parse ip: " + e);
+                return;
+            }
+            int port = Port.GetValue(context);
+            if (_connected) CheckChanges(address, port);
+            else ConnectOSC(address, port);
+        }
+
+        // Connection changed, let's close and reset it.
+        private void CheckChanges(IPAddress address, int port)
+        {
+            if (address != _address || port != _port)
+            {
+                _sender.Close();
+                ConnectOSC(address, port);
+            }
+        }
+
+        private void ConnectOSC(IPAddress address, int port)
+        {
+            try {
+                _sender = new OscSender(address, port);
+                _sender.Connect();
+                if (_sender.State == OscSocketState.Connected) {
+                    _address = address;
+                    _port = port;
+                    _connected = true;
+                    return;
+                }
+            }
+            catch (Exception e) {
+                Log.Error("Connection failure: " + e);
+            }
+            _connected = false;
+        }
+
+        [Input(Guid = "98f38caa-4f79-425c-ab46-22d7dbe62978")]
+        public readonly InputSlot<string> Address = new InputSlot<string>();
+
+        [Input(Guid = "6c0e07ba-7ea6-4dab-af0b-61cf9cb74ad7")]
+        public readonly InputSlot<int> Port = new InputSlot<int>();
+
+
+        [Input(Guid = "9016e418-7761-4916-aafb-c95599f77f38")]
+        public readonly InputSlot<string> Location = new InputSlot<string>();
+
+        [Input(Guid = "d5e9e9be-093b-4d57-9070-9b2cf33aa45b")]
+        public readonly InputSlot<string> String = new InputSlot<string>();
+
+        [Input(Guid = "827c7ae2-c129-4d04-a715-328c0a86bf8a")]
+        public readonly InputSlot<float> Number = new InputSlot<float>();
+
+        [Input(Guid = "4931217b-e30d-42a6-9cda-bc49a8fd8d67", MappedType = typeof(OscType))]
+        public readonly InputSlot<int> OscValueType = new ();
+
+        [Output(Guid = "a6679d6c-fc34-4588-ab20-5079ad8f8a03")]
+        public readonly Slot<T3.Core.DataTypes.Command> Result = new Slot<T3.Core.DataTypes.Command>();
+    }
+}

--- a/Operators/Types/lib/io/osc/OscOutput_4e99da86-482f-4037-8664-b2371526d632.t3
+++ b/Operators/Types/lib/io/osc/OscOutput_4e99da86-482f-4037-8664-b2371526d632.t3
@@ -1,0 +1,33 @@
+{
+  "Name": "OscOutput",
+  "Id": "4e99da86-482f-4037-8664-b2371526d632",
+  "Namespace": "lib.io.osc",
+  "Inputs": [
+    {
+      "Id": "98f38caa-4f79-425c-ab46-22d7dbe62978"/*Address*/,
+      "DefaultValue": "127.0.0.1"
+    },
+    {
+      "Id": "6c0e07ba-7ea6-4dab-af0b-61cf9cb74ad7"/*Port*/,
+      "DefaultValue": 9000
+    },
+    {
+      "Id": "9016e418-7761-4916-aafb-c95599f77f38"/*Location*/,
+      "DefaultValue": ""
+    },
+    {
+      "Id": "d5e9e9be-093b-4d57-9070-9b2cf33aa45b"/*String*/,
+      "DefaultValue": ""
+    },
+    {
+      "Id": "827c7ae2-c129-4d04-a715-328c0a86bf8a"/*Number*/,
+      "DefaultValue": 0.0
+    },
+    {
+      "Id": "4931217b-e30d-42a6-9cda-bc49a8fd8d67"/*OscValueType*/,
+      "DefaultValue": 0
+    }
+  ],
+  "Children": [],
+  "Connections": []
+}

--- a/Operators/Types/lib/io/osc/OscOutput_4e99da86-482f-4037-8664-b2371526d632.t3
+++ b/Operators/Types/lib/io/osc/OscOutput_4e99da86-482f-4037-8664-b2371526d632.t3
@@ -4,7 +4,7 @@
   "Namespace": "lib.io.osc",
   "Inputs": [
     {
-      "Id": "98f38caa-4f79-425c-ab46-22d7dbe62978"/*Address*/,
+      "Id": "98f38caa-4f79-425c-ab46-22d7dbe62978"/*IpAddress*/,
       "DefaultValue": "127.0.0.1"
     },
     {

--- a/Operators/Types/lib/io/osc/OscOutput_4e99da86-482f-4037-8664-b2371526d632.t3ui
+++ b/Operators/Types/lib/io/osc/OscOutput_4e99da86-482f-4037-8664-b2371526d632.t3ui
@@ -1,0 +1,61 @@
+{
+  "Id": "4e99da86-482f-4037-8664-b2371526d632"/*OscOutput*/,
+  "Description": "Send out OSC signals to a server",
+  "InputUis": [
+    {
+      "InputId": "98f38caa-4f79-425c-ab46-22d7dbe62978"/*Address*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 0.0
+      },
+      "Usage": "Default"
+    },
+    {
+      "InputId": "6c0e07ba-7ea6-4dab-af0b-61cf9cb74ad7"/*Port*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 45.0
+      }
+    },
+    {
+      "InputId": "9016e418-7761-4916-aafb-c95599f77f38"/*Location*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 135.0
+      },
+      "Usage": "Default"
+    },
+    {
+      "InputId": "d5e9e9be-093b-4d57-9070-9b2cf33aa45b"/*String*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 225.0
+      },
+      "Usage": "Default"
+    },
+    {
+      "InputId": "827c7ae2-c129-4d04-a715-328c0a86bf8a"/*Number*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 180.0
+      }
+    },
+    {
+      "InputId": "4931217b-e30d-42a6-9cda-bc49a8fd8d67"/*OscValueType*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 270.0
+      }
+    }
+  ],
+  "SymbolChildUis": [],
+  "OutputUis": [
+    {
+      "OutputId": "a6679d6c-fc34-4588-ab20-5079ad8f8a03"/*Result*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 200.0
+      }
+    }
+  ]
+}

--- a/Operators/Types/lib/io/osc/OscOutput_4e99da86-482f-4037-8664-b2371526d632.t3ui
+++ b/Operators/Types/lib/io/osc/OscOutput_4e99da86-482f-4037-8664-b2371526d632.t3ui
@@ -3,7 +3,7 @@
   "Description": "Send out OSC signals to a server",
   "InputUis": [
     {
-      "InputId": "98f38caa-4f79-425c-ab46-22d7dbe62978"/*Address*/,
+      "InputId": "98f38caa-4f79-425c-ab46-22d7dbe62978"/*IpAddress*/,
       "Position": {
         "X": -200.0,
         "Y": 0.0

--- a/Operators/Types/user/fuzzy/osc/OscOutputExample.cs
+++ b/Operators/Types/user/fuzzy/osc/OscOutputExample.cs
@@ -1,0 +1,15 @@
+using T3.Core.Operator;
+using T3.Core.Operator.Attributes;
+using T3.Core.Operator.Slots;
+
+namespace T3.Operators.Types.Id_48e284ff_cfcc_4d6c_83d4_256c9380de61
+{
+    public class OscOutputExample : Instance<OscOutputExample>
+    {
+
+        [Output(Guid = "bbf85f4a-f11f-47cf-8689-c059955117ce")]
+        public readonly Slot<T3.Core.DataTypes.Command> OSCExecute = new Slot<T3.Core.DataTypes.Command>();
+
+    }
+}
+

--- a/Operators/Types/user/fuzzy/osc/OscOutputExample_48e284ff-cfcc-4d6c-83d4-256c9380de61.t3
+++ b/Operators/Types/user/fuzzy/osc/OscOutputExample_48e284ff-cfcc-4d6c-83d4-256c9380de61.t3
@@ -9,7 +9,7 @@
       "SymbolId": "4e99da86-482f-4037-8664-b2371526d632",
       "InputValues": [
         {
-          "Id": "98f38caa-4f79-425c-ab46-22d7dbe62978"/*Address*/,
+          "Id": "98f38caa-4f79-425c-ab46-22d7dbe62978"/*IpAddress*/,
           "Type": "System.String",
           "Value": "192.168.1.19"
         },
@@ -49,7 +49,7 @@
         {
           "Id": "2d9c040d-5244-40ac-8090-d8d57323487b"/*SpeedFactor*/,
           "Type": "System.Single",
-          "Value": 2.0
+          "Value": 1.0
         }
       ],
       "Outputs": []
@@ -59,7 +59,7 @@
       "SymbolId": "4e99da86-482f-4037-8664-b2371526d632",
       "InputValues": [
         {
-          "Id": "98f38caa-4f79-425c-ab46-22d7dbe62978"/*Address*/,
+          "Id": "98f38caa-4f79-425c-ab46-22d7dbe62978"/*IpAddress*/,
           "Type": "System.String",
           "Value": "192.168.1.19"
         },

--- a/Operators/Types/user/fuzzy/osc/OscOutputExample_48e284ff-cfcc-4d6c-83d4-256c9380de61.t3
+++ b/Operators/Types/user/fuzzy/osc/OscOutputExample_48e284ff-cfcc-4d6c-83d4-256c9380de61.t3
@@ -1,0 +1,254 @@
+{
+  "Name": "OscOutputExample",
+  "Id": "48e284ff-cfcc-4d6c-83d4-256c9380de61",
+  "Namespace": "user.fuzzy.osc",
+  "Inputs": [],
+  "Children": [
+    {
+      "Id": "eacb39bd-1acb-4db5-a540-5a1d7a5b28c3"/*OscOutput*/,
+      "SymbolId": "4e99da86-482f-4037-8664-b2371526d632",
+      "InputValues": [
+        {
+          "Id": "98f38caa-4f79-425c-ab46-22d7dbe62978"/*Address*/,
+          "Type": "System.String",
+          "Value": "192.168.1.19"
+        },
+        {
+          "Id": "9016e418-7761-4916-aafb-c95599f77f38"/*Location*/,
+          "Type": "System.String",
+          "Value": "/label1"
+        },
+        {
+          "Id": "d5e9e9be-093b-4d57-9070-9b2cf33aa45b"/*String*/,
+          "Type": "System.String",
+          "Value": "1"
+        },
+        {
+          "Id": "827c7ae2-c129-4d04-a715-328c0a86bf8a"/*Number*/,
+          "Type": "System.Single",
+          "Value": 0.67
+        },
+        {
+          "Id": "4931217b-e30d-42a6-9cda-bc49a8fd8d67"/*OscValueType*/,
+          "Type": "System.Int32",
+          "Value": 1
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "4cba430a-43ad-4f8f-ba6d-6f4a5453fb0f"/*Execute*/,
+      "SymbolId": "936e4324-bea2-463a-b196-6064a2d8a6b2",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "eebbe86b-d85b-4746-a4ad-02e1945aafed"/*Time*/,
+      "SymbolId": "9cb4d49e-135b-400b-a035-2b02c5ea6a72",
+      "InputValues": [
+        {
+          "Id": "2d9c040d-5244-40ac-8090-d8d57323487b"/*SpeedFactor*/,
+          "Type": "System.Single",
+          "Value": 2.0
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "a35907d0-b702-43ba-bd37-0e30e6b6ac3e"/*OscOutput*/,
+      "SymbolId": "4e99da86-482f-4037-8664-b2371526d632",
+      "InputValues": [
+        {
+          "Id": "98f38caa-4f79-425c-ab46-22d7dbe62978"/*Address*/,
+          "Type": "System.String",
+          "Value": "192.168.1.19"
+        },
+        {
+          "Id": "9016e418-7761-4916-aafb-c95599f77f38"/*Location*/,
+          "Type": "System.String",
+          "Value": "/fader1"
+        },
+        {
+          "Id": "d5e9e9be-093b-4d57-9070-9b2cf33aa45b"/*String*/,
+          "Type": "System.String",
+          "Value": "1"
+        },
+        {
+          "Id": "827c7ae2-c129-4d04-a715-328c0a86bf8a"/*Number*/,
+          "Type": "System.Single",
+          "Value": 0.67
+        },
+        {
+          "Id": "4931217b-e30d-42a6-9cda-bc49a8fd8d67"/*OscValueType*/,
+          "Type": "System.Int32",
+          "Value": 0
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "6fcdcfdc-53c5-4ea1-a305-0b6fa9ee028a"/*PickFromStringList*/,
+      "SymbolId": "ef357e66-24e9-4f54-8d86-869db74602f4",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "b184252e-9660-446a-81e3-7d5b79a10005"/*FloatToInt*/,
+      "SymbolId": "06b4728e-852c-491a-a89d-647f7e0b5415",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "9dfb7763-5d91-4b7f-9e92-28fea322e937"/*MockStrings*/,
+      "SymbolId": "3af25959-fd3f-4608-b521-5860d82554df",
+      "InputValues": [
+        {
+          "Id": "054ade21-c08e-4633-9725-6168fd7806f9"/*Category*/,
+          "Type": "System.Int32",
+          "Value": 6
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "00f92770-c4b4-4307-8412-8dc088f5d19d"/*ModInt*/,
+      "SymbolId": "cf3268d7-4f3d-47bd-8cb5-0214c75432ec",
+      "InputValues": [
+        {
+          "Id": "ccdea113-c046-4ec2-b1fb-30d6e15db7ce"/*Mod*/,
+          "Type": "System.Int32",
+          "Value": 30
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "2bc308e9-70ec-447e-a51c-0d3db658895a"/*SplitString*/,
+      "SymbolId": "a0fcf7ed-1f14-4a8b-a57e-99e5b2407b1b",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "b2421772-2464-45a0-b872-2bde4812d0b9"/*Modulo*/,
+      "SymbolId": "5202d3f6-c970-4006-933d-3c60d6c202dc",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "d77b1417-3d8b-403c-897d-e65973d98be2"/*IntValue*/,
+      "SymbolId": "cc07b314-4582-4c2c-84b8-bb32f59fc09b",
+      "InputValues": [
+        {
+          "Id": "4515c98e-05bc-4186-8773-4d2b31a8c323"/*Int*/,
+          "Type": "System.Int32",
+          "Value": 9000
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "8b10c6d6-5d05-40db-82c4-4f01729e7b71"/*AString*/,
+      "SymbolId": "5880cbc3-a541-4484-a06a-0e6f77cdbe8e",
+      "InputValues": [
+        {
+          "Id": "ceeae47b-d792-471d-a825-49e22749b7b9"/*InputString*/,
+          "Type": "System.String",
+          "Value": "192.168.1.19"
+        }
+      ],
+      "Outputs": []
+    }
+  ],
+  "Connections": [
+    {
+      "SourceParentOrChildId": "4cba430a-43ad-4f8f-ba6d-6f4a5453fb0f",
+      "SourceSlotId": "e81c99ce-fcee-4e7c-a1c7-0aa3b352b7e1",
+      "TargetParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "TargetSlotId": "bbf85f4a-f11f-47cf-8689-c059955117ce"
+    },
+    {
+      "SourceParentOrChildId": "b184252e-9660-446a-81e3-7d5b79a10005",
+      "SourceSlotId": "1eb7c5c4-0982-43f4-b14d-524571e3cdda",
+      "TargetParentOrChildId": "00f92770-c4b4-4307-8412-8dc088f5d19d",
+      "TargetSlotId": "3528f4d3-3529-4551-9dc1-e1dafe6b0669"
+    },
+    {
+      "SourceParentOrChildId": "9dfb7763-5d91-4b7f-9e92-28fea322e937",
+      "SourceSlotId": "461d8e3a-b4db-4a12-94c5-c791e347e51f",
+      "TargetParentOrChildId": "2bc308e9-70ec-447e-a51c-0d3db658895a",
+      "TargetSlotId": "b1fd8b37-140e-487f-bfe2-bc426d8fe439"
+    },
+    {
+      "SourceParentOrChildId": "eacb39bd-1acb-4db5-a540-5a1d7a5b28c3",
+      "SourceSlotId": "a6679d6c-fc34-4588-ab20-5079ad8f8a03",
+      "TargetParentOrChildId": "4cba430a-43ad-4f8f-ba6d-6f4a5453fb0f",
+      "TargetSlotId": "5d73ebe6-9aa0-471a-ae6b-3f5bfd5a0f9c"
+    },
+    {
+      "SourceParentOrChildId": "a35907d0-b702-43ba-bd37-0e30e6b6ac3e",
+      "SourceSlotId": "a6679d6c-fc34-4588-ab20-5079ad8f8a03",
+      "TargetParentOrChildId": "4cba430a-43ad-4f8f-ba6d-6f4a5453fb0f",
+      "TargetSlotId": "5d73ebe6-9aa0-471a-ae6b-3f5bfd5a0f9c"
+    },
+    {
+      "SourceParentOrChildId": "00f92770-c4b4-4307-8412-8dc088f5d19d",
+      "SourceSlotId": "8fed46e4-b9df-4d56-b098-9c9a17775139",
+      "TargetParentOrChildId": "6fcdcfdc-53c5-4ea1-a305-0b6fa9ee028a",
+      "TargetSlotId": "12ce5fe3-750f-47ed-9507-416cb327a615"
+    },
+    {
+      "SourceParentOrChildId": "2bc308e9-70ec-447e-a51c-0d3db658895a",
+      "SourceSlotId": "52745502-3b69-4b2e-be47-d2660fe08e48",
+      "TargetParentOrChildId": "6fcdcfdc-53c5-4ea1-a305-0b6fa9ee028a",
+      "TargetSlotId": "8d5e77a6-1ec4-4979-ad26-f7862049bce1"
+    },
+    {
+      "SourceParentOrChildId": "d77b1417-3d8b-403c-897d-e65973d98be2",
+      "SourceSlotId": "8a65b34b-40be-4dbf-812c-d4c663464c7f",
+      "TargetParentOrChildId": "a35907d0-b702-43ba-bd37-0e30e6b6ac3e",
+      "TargetSlotId": "6c0e07ba-7ea6-4dab-af0b-61cf9cb74ad7"
+    },
+    {
+      "SourceParentOrChildId": "b2421772-2464-45a0-b872-2bde4812d0b9",
+      "SourceSlotId": "4e4ebbcf-6b12-4ce7-9bec-78cd9049e239",
+      "TargetParentOrChildId": "a35907d0-b702-43ba-bd37-0e30e6b6ac3e",
+      "TargetSlotId": "827c7ae2-c129-4d04-a715-328c0a86bf8a"
+    },
+    {
+      "SourceParentOrChildId": "8b10c6d6-5d05-40db-82c4-4f01729e7b71",
+      "SourceSlotId": "dd9d8718-addc-49b1-bd33-aac22b366f94",
+      "TargetParentOrChildId": "a35907d0-b702-43ba-bd37-0e30e6b6ac3e",
+      "TargetSlotId": "98f38caa-4f79-425c-ab46-22d7dbe62978"
+    },
+    {
+      "SourceParentOrChildId": "eebbe86b-d85b-4746-a4ad-02e1945aafed",
+      "SourceSlotId": "b20573fe-7a7e-48e1-9370-744288ca6e32",
+      "TargetParentOrChildId": "b184252e-9660-446a-81e3-7d5b79a10005",
+      "TargetSlotId": "af866a6c-1ab0-43c0-9e8a-5d25c300e128"
+    },
+    {
+      "SourceParentOrChildId": "eebbe86b-d85b-4746-a4ad-02e1945aafed",
+      "SourceSlotId": "b20573fe-7a7e-48e1-9370-744288ca6e32",
+      "TargetParentOrChildId": "b2421772-2464-45a0-b872-2bde4812d0b9",
+      "TargetSlotId": "8a401e5d-295d-4403-a3af-1d6b91ce3dba"
+    },
+    {
+      "SourceParentOrChildId": "d77b1417-3d8b-403c-897d-e65973d98be2",
+      "SourceSlotId": "8a65b34b-40be-4dbf-812c-d4c663464c7f",
+      "TargetParentOrChildId": "eacb39bd-1acb-4db5-a540-5a1d7a5b28c3",
+      "TargetSlotId": "6c0e07ba-7ea6-4dab-af0b-61cf9cb74ad7"
+    },
+    {
+      "SourceParentOrChildId": "8b10c6d6-5d05-40db-82c4-4f01729e7b71",
+      "SourceSlotId": "dd9d8718-addc-49b1-bd33-aac22b366f94",
+      "TargetParentOrChildId": "eacb39bd-1acb-4db5-a540-5a1d7a5b28c3",
+      "TargetSlotId": "98f38caa-4f79-425c-ab46-22d7dbe62978"
+    },
+    {
+      "SourceParentOrChildId": "6fcdcfdc-53c5-4ea1-a305-0b6fa9ee028a",
+      "SourceSlotId": "467bb46e-3391-48a7-b0eb-f7fd9d77b60f",
+      "TargetParentOrChildId": "eacb39bd-1acb-4db5-a540-5a1d7a5b28c3",
+      "TargetSlotId": "d5e9e9be-093b-4d57-9070-9b2cf33aa45b"
+    }
+  ]
+}

--- a/Operators/Types/user/fuzzy/osc/OscOutputExample_48e284ff-cfcc-4d6c-83d4-256c9380de61.t3ui
+++ b/Operators/Types/user/fuzzy/osc/OscOutputExample_48e284ff-cfcc-4d6c-83d4-256c9380de61.t3ui
@@ -1,0 +1,135 @@
+{
+  "Id": "48e284ff-cfcc-4d6c-83d4-256c9380de61"/*OscOutputExample*/,
+  "Description": "shows what the OscOutput operator can do.",
+  "InputUis": [],
+  "SymbolChildUis": [
+    {
+      "ChildId": "eacb39bd-1acb-4db5-a540-5a1d7a5b28c3"/*OscOutput*/,
+      "Style": "Expanded",
+      "Size": {
+        "X": 110.0,
+        "Y": 101.0
+      },
+      "Position": {
+        "X": 611.8196,
+        "Y": 298.29492
+      }
+    },
+    {
+      "ChildId": "4cba430a-43ad-4f8f-ba6d-6f4a5453fb0f"/*Execute*/,
+      "Position": {
+        "X": 752.6626,
+        "Y": 369.9673
+      }
+    },
+    {
+      "ChildId": "eebbe86b-d85b-4746-a4ad-02e1945aafed"/*Time*/,
+      "Position": {
+        "X": 0.0,
+        "Y": 401.56934
+      }
+    },
+    {
+      "ChildId": "a35907d0-b702-43ba-bd37-0e30e6b6ac3e"/*OscOutput*/,
+      "Style": "Expanded",
+      "Size": {
+        "X": 110.0,
+        "Y": 101.0
+      },
+      "Position": {
+        "X": 611.8196,
+        "Y": 419.29492
+      }
+    },
+    {
+      "ChildId": "6fcdcfdc-53c5-4ea1-a305-0b6fa9ee028a"/*PickFromStringList*/,
+      "Position": {
+        "X": 445.91553,
+        "Y": 179.32959
+      }
+    },
+    {
+      "ChildId": "b184252e-9660-446a-81e3-7d5b79a10005"/*FloatToInt*/,
+      "Position": {
+        "X": 157.00049,
+        "Y": 332.44092
+      }
+    },
+    {
+      "ChildId": "9dfb7763-5d91-4b7f-9e92-28fea322e937"/*MockStrings*/,
+      "Style": "Expanded",
+      "Size": {
+        "X": 110.0,
+        "Y": 36.0
+      },
+      "Position": {
+        "X": 145.91553,
+        "Y": 179.32959
+      }
+    },
+    {
+      "ChildId": "00f92770-c4b4-4307-8412-8dc088f5d19d"/*ModInt*/,
+      "Position": {
+        "X": 295.91553,
+        "Y": 255.32959
+      }
+    },
+    {
+      "ChildId": "2bc308e9-70ec-447e-a51c-0d3db658895a"/*SplitString*/,
+      "Position": {
+        "X": 295.91553,
+        "Y": 179.32959
+      }
+    },
+    {
+      "ChildId": "b2421772-2464-45a0-b872-2bde4812d0b9"/*Modulo*/,
+      "Position": {
+        "X": 150.0,
+        "Y": 401.56934
+      }
+    },
+    {
+      "ChildId": "d77b1417-3d8b-403c-897d-e65973d98be2"/*IntValue*/,
+      "Position": {
+        "X": 409.28687,
+        "Y": 43.0
+      }
+    },
+    {
+      "ChildId": "8b10c6d6-5d05-40db-82c4-4f01729e7b71"/*AString*/,
+      "Position": {
+        "X": 409.28687,
+        "Y": 0.0
+      }
+    }
+  ],
+  "OutputUis": [
+    {
+      "OutputId": "bbf85f4a-f11f-47cf-8689-c059955117ce"/*OSCExecute*/,
+      "Position": {
+        "X": 852.6626,
+        "Y": 209.64746
+      }
+    }
+  ],
+  "Annotations": [
+    {
+      "Id": "d28956a0-5be2-4264-b73a-dfe0668896da",
+      "Title": "address:port, only dotted IP4 are supported.",
+      "Color": {
+        "X": 0.6,
+        "Y": 0.6,
+        "Z": 0.6,
+        "W": 1.0
+      },
+      "Position": {
+        "X": 370.99146,
+        "Y": -15.898926
+      },
+      "Size": {
+        "X": 212.2937,
+        "Y": 156.38626
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This is a new operator, counterpart to OscInput
It _only_ supports strings and float numbers, it tries to fail gracefully on bad location and failure to connect.
Error and state check is grunty, please advise if I'm doing it too wrong.