### PR TITLE
Feature/ An Operator to visualize the UV map of a mesh 

### DIFF
--- a/Operators/Types/examples/lib/3d/mesh/UVsViewerExample.cs
+++ b/Operators/Types/examples/lib/3d/mesh/UVsViewerExample.cs
@@ -1,0 +1,16 @@
+using SharpDX.Direct3D11;
+using T3.Core.Operator;
+using T3.Core.Operator.Attributes;
+using T3.Core.Operator.Slots;
+
+namespace T3.Operators.Types.Id_70e97e6b_3ddf_4a88_b080_c63fdbd251c9
+{
+    public class UVsViewerExample : Instance<UVsViewerExample>
+    {
+        [Output(Guid = "7c291a16-1e48-40c6-9fbc-cab14bb80720")]
+        public readonly Slot<Texture2D> ColorBuffer = new Slot<Texture2D>();
+
+
+    }
+}
+

--- a/Operators/Types/examples/lib/3d/mesh/UVsViewerExample_70e97e6b-3ddf-4a88-b080-c63fdbd251c9.t3
+++ b/Operators/Types/examples/lib/3d/mesh/UVsViewerExample_70e97e6b-3ddf-4a88-b080-c63fdbd251c9.t3
@@ -1,0 +1,391 @@
+{
+  "Name": "UVsViewerExample",
+  "Id": "70e97e6b-3ddf-4a88-b080-c63fdbd251c9",
+  "Namespace": "examples.lib.3d.mesh",
+  "Inputs": [],
+  "Children": [
+    {
+      "Id": "1561965d-0885-4f00-9a50-b669f78ea80a"/*UVsViewer*/,
+      "SymbolId": "68cf773d-30ac-4ae0-bc1e-b7a17ea322bb",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "80414f93-388e-4d5d-a2e3-dc542d4d51ac"/*SphereMesh*/,
+      "SymbolId": "5fb3dafe-aed4-4fff-a5b9-c144ea023d35",
+      "InputValues": [
+        {
+          "Id": "6f327667-9054-4952-9f8f-570fa5497b13"/*Segments*/,
+          "Type": "T3.Core.DataTypes.Vector.Int2",
+          "Value": {
+            "X": 32,
+            "Y": 32
+          }
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "173781a9-55aa-4412-bfd0-75db58a79d89"/*DrawMesh*/,
+      "SymbolId": "a3c5471e-079b-4d4b-886a-ec02d6428ff6",
+      "InputValues": [
+        {
+          "Id": "2c4b5f3a-e9ec-432e-b1ae-6d999ae44f1b"/*FillMode*/,
+          "Type": "System.Int32",
+          "Value": 3
+        },
+        {
+          "Id": "9e957f4a-6502-4905-8d97-331f8b54097c"/*Culling*/,
+          "Type": "SharpDX.Direct3D11.CullMode",
+          "Value": "Back"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "11633d13-d6af-4157-a6f8-7a17177a20bd"/*SetMaterial*/,
+      "SymbolId": "0ed2bee3-641f-4b08-8685-df1506e9af3c",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "244a53c5-1261-44aa-89a4-13316e18efaf"/*CheckerBoard*/,
+      "SymbolId": "1a411be2-1757-4019-8ce2-e29f808ed839",
+      "InputValues": [
+        {
+          "Id": "1192cfbe-585f-45f0-a37b-5fe78ca32d7b"/*ColorA*/,
+          "Type": "System.Numerics.Vector4",
+          "Value": {
+            "X": 1.0,
+            "Y": 0.99999005,
+            "Z": 0.99999005,
+            "W": 1.0
+          }
+        },
+        {
+          "Id": "b08aba90-f33f-4402-bb7b-bcfc4bb624ce"/*ColorB*/,
+          "Type": "System.Numerics.Vector4",
+          "Value": {
+            "X": 0.784689,
+            "Y": 0.7846813,
+            "Z": 0.7846813,
+            "W": 1.0
+          }
+        },
+        {
+          "Id": "e367bd72-c37c-4a7f-8441-698161ba75f8"/*Scale*/,
+          "Type": "System.Single",
+          "Value": 0.125
+        },
+        {
+          "Id": "63ebb6c9-e8a5-43e4-97a4-3a34ad585474"/*Resolution*/,
+          "Type": "T3.Core.DataTypes.Vector.Int2",
+          "Value": {
+            "X": 512,
+            "Y": 512
+          }
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "3d739213-68fd-4880-82d0-c3a265d44fc8"/*UVmap*/,
+      "SymbolId": "ed0f5188-8888-453e-8db4-20d87d18e9f4",
+      "Name": "UVmap",
+      "InputValues": [
+        {
+          "Id": "e7c1f0af-da6d-4e33-ac86-7dc96bfe7eb3"/*BoolValue*/,
+          "Type": "System.Boolean",
+          "Value": true
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "c39742ab-6ae0-427d-8206-a7a82281e101"/*TriggerAnim*/,
+      "SymbolId": "95d586a2-ee14-4ff5-a5bb-40c497efde95",
+      "InputValues": [
+        {
+          "Id": "9913fcea-3994-40d6-84a1-d56525b31c43"/*AnimMode*/,
+          "Type": "System.Int32",
+          "Value": 2
+        },
+        {
+          "Id": "0d56fc27-fa15-4f1e-aa09-f97af93d42c7"/*Duration*/,
+          "Type": "System.Single",
+          "Value": 0.25
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "fad09e3f-6564-4c70-9802-5618999c24c3"/*TorusMesh*/,
+      "SymbolId": "a835ab86-29c1-438e-a7f7-2e297108bfd5",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "5a83a84f-5b2a-4028-b35d-b6c478632844"/*CylinderMesh*/,
+      "SymbolId": "5777a005-bbae-48d6-b633-5e998ca76c91",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "7e530b71-92dc-4dbc-a4a3-bfd039a35788"/*CommonPointSets*/,
+      "SymbolId": "353f63fc-e613-43ca-b037-02d7b9f4e935",
+      "InputValues": [
+        {
+          "Id": "2ba96aee-ff89-41bd-90c5-c6c36907b6e4"/*Set*/,
+          "Type": "System.Int32",
+          "Value": 3
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "b58bbea3-7b0d-4da9-9f77-db2ea51a1dcd"/*TransformPoints*/,
+      "SymbolId": "7f6c64fe-ca2e-445e-a9b4-c70291ce354e",
+      "InputValues": [
+        {
+          "Id": "9e803bd1-c5a3-4f6f-926d-d19f32dcbae5"/*Translation*/,
+          "Type": "System.Numerics.Vector3",
+          "Value": {
+            "X": 0.5,
+            "Y": 0.5,
+            "Z": 0.0
+          }
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "ba6906c5-56b3-4bc8-a52e-f28930332f6d"/*DrawLines*/,
+      "SymbolId": "836f211f-b387-417c-8316-658e0dc6e117",
+      "InputValues": [
+        {
+          "Id": "75419a73-8a3e-4538-9a1d-e3b0ce7f8561"/*Color*/,
+          "Type": "System.Numerics.Vector4",
+          "Value": {
+            "X": 1.0,
+            "Y": 1.0,
+            "Z": 1.0,
+            "W": 0.5
+          }
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "e84b8af2-00ae-46ab-9d5c-b99320291b2b"/*Camera*/,
+      "SymbolId": "746d886c-5ab6-44b1-bb15-f3ce2fadf7e6",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "fddaebf7-f580-41c2-9670-d484ae751bb1"/*RenderTarget*/,
+      "SymbolId": "f9fe78c5-43a6-48ae-8e8c-6cdbbc330dd1",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "ba6343aa-25e0-41a9-8fbe-76aa35147bfc"/*Text*/,
+      "SymbolId": "fd31d208-12fe-46bf-bfa3-101211f8f497",
+      "InputValues": [
+        {
+          "Id": "0e5f05b4-5e8a-4f6d-8cac-03b04649eb67"/*Color*/,
+          "Type": "System.Numerics.Vector4",
+          "Value": {
+            "X": 1.0,
+            "Y": 0.0,
+            "Z": 0.616446,
+            "W": 1.0
+          }
+        },
+        {
+          "Id": "de0fed7d-d2af-4424-baf3-81606e26559f"/*Position*/,
+          "Type": "System.Numerics.Vector2",
+          "Value": {
+            "X": 0.0,
+            "Y": -0.418
+          }
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "51020cfd-c08d-49d7-b088-26fcfa549e4d"/*RenderTarget*/,
+      "SymbolId": "f9fe78c5-43a6-48ae-8e8c-6cdbbc330dd1",
+      "InputValues": [
+        {
+          "Id": "8bb4a4e5-0c88-4d99-a5b2-2c9e22bd301f"/*ClearColor*/,
+          "Type": "System.Numerics.Vector4",
+          "Value": {
+            "X": 1.0,
+            "Y": 1.0,
+            "Z": 1.0,
+            "W": 0.060000002
+          }
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "7dcb5f73-b565-4c42-b0b5-4089951481e0"/*Blend*/,
+      "SymbolId": "9f43f769-d32a-4f49-92ac-e0be3ba250cf",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "6ad219dc-2b77-42e7-8503-eab6882d3125"/*PickMeshBuffer*/,
+      "SymbolId": "845371ef-a5c2-4ca2-8315-ea2b62f63ee2",
+      "InputValues": [
+        {
+          "Id": "076afdcc-c9af-4875-b97a-d8132996b35a"/*Index*/,
+          "Type": "System.Int32",
+          "Value": 0
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "b5bb5ebd-7663-40d8-9116-71181ad681cf"/*LoadObj*/,
+      "SymbolId": "be52b670-9749-4c0d-89f0-d8b101395227",
+      "InputValues": [
+        {
+          "Id": "7d576017-89bd-4813-bc9b-70214efe6a27"/*Path*/,
+          "Type": "System.String",
+          "Value": "Resources\\common\\meshes\\marblePlayer.obj"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "fd42e3c7-f346-4594-8ff7-38bed198000b"/*Group*/,
+      "SymbolId": "a3f64d34-1fab-4230-86b3-1c3deba3f90b",
+      "InputValues": [],
+      "Outputs": []
+    }
+  ],
+  "Connections": [
+    {
+      "SourceParentOrChildId": "fddaebf7-f580-41c2-9670-d484ae751bb1",
+      "SourceSlotId": "7a4c4feb-be2f-463e-96c6-cd9a6bad77a2",
+      "TargetParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "TargetSlotId": "7c291a16-1e48-40c6-9fbc-cab14bb80720"
+    },
+    {
+      "SourceParentOrChildId": "7dcb5f73-b565-4c42-b0b5-4089951481e0",
+      "SourceSlotId": "536fae14-b814-498c-a6b4-07775de36991",
+      "TargetParentOrChildId": "11633d13-d6af-4157-a6f8-7a17177a20bd",
+      "TargetSlotId": "0eb51df1-570a-4ac6-bae6-5e03d6e66ceb"
+    },
+    {
+      "SourceParentOrChildId": "173781a9-55aa-4412-bfd0-75db58a79d89",
+      "SourceSlotId": "53b3fdca-9d5e-4808-a02f-4aa743cd8456",
+      "TargetParentOrChildId": "11633d13-d6af-4157-a6f8-7a17177a20bd",
+      "TargetSlotId": "2a585a23-b60c-4c8b-8cfa-9ab2a8b04c7a"
+    },
+    {
+      "SourceParentOrChildId": "c39742ab-6ae0-427d-8206-a7a82281e101",
+      "SourceSlotId": "aac4ecbf-436a-4414-94c1-53d517a8e587",
+      "TargetParentOrChildId": "1561965d-0885-4f00-9a50-b669f78ea80a",
+      "TargetSlotId": "017cf5d0-5e39-480e-9a23-ce3d6e1c0d40"
+    },
+    {
+      "SourceParentOrChildId": "6ad219dc-2b77-42e7-8503-eab6882d3125",
+      "SourceSlotId": "2f4733f8-adf1-4a6d-b207-5ee2d566cae3",
+      "TargetParentOrChildId": "1561965d-0885-4f00-9a50-b669f78ea80a",
+      "TargetSlotId": "4ccfb3fe-5c64-45d6-8b3f-63249c69e146"
+    },
+    {
+      "SourceParentOrChildId": "1561965d-0885-4f00-9a50-b669f78ea80a",
+      "SourceSlotId": "6ac1d050-592c-4533-9b5e-c9e62884c992",
+      "TargetParentOrChildId": "173781a9-55aa-4412-bfd0-75db58a79d89",
+      "TargetSlotId": "97429e1f-3f30-4789-89a6-8e930e356ee6"
+    },
+    {
+      "SourceParentOrChildId": "ba6343aa-25e0-41a9-8fbe-76aa35147bfc",
+      "SourceSlotId": "3f8b20a7-c8b8-45ab-86a1-0efcd927358e",
+      "TargetParentOrChildId": "51020cfd-c08d-49d7-b088-26fcfa549e4d",
+      "TargetSlotId": "4da253b7-4953-439a-b03f-1d515a78bddf"
+    },
+    {
+      "SourceParentOrChildId": "5a83a84f-5b2a-4028-b35d-b6c478632844",
+      "SourceSlotId": "b4bed6e3-bef5-4601-99bd-f85bf1a956f5",
+      "TargetParentOrChildId": "6ad219dc-2b77-42e7-8503-eab6882d3125",
+      "TargetSlotId": "7bb6f999-214a-448a-a7f7-be447113785e"
+    },
+    {
+      "SourceParentOrChildId": "fad09e3f-6564-4c70-9802-5618999c24c3",
+      "SourceSlotId": "f8f17f87-56f2-4411-b9bf-b9193b9aa90d",
+      "TargetParentOrChildId": "6ad219dc-2b77-42e7-8503-eab6882d3125",
+      "TargetSlotId": "7bb6f999-214a-448a-a7f7-be447113785e"
+    },
+    {
+      "SourceParentOrChildId": "80414f93-388e-4d5d-a2e3-dc542d4d51ac",
+      "SourceSlotId": "322717ef-3a76-4e23-845f-a12a03d73969",
+      "TargetParentOrChildId": "6ad219dc-2b77-42e7-8503-eab6882d3125",
+      "TargetSlotId": "7bb6f999-214a-448a-a7f7-be447113785e"
+    },
+    {
+      "SourceParentOrChildId": "b5bb5ebd-7663-40d8-9116-71181ad681cf",
+      "SourceSlotId": "1f4e7cac-1f62-4633-b0f3-a3017a026753",
+      "TargetParentOrChildId": "6ad219dc-2b77-42e7-8503-eab6882d3125",
+      "TargetSlotId": "7bb6f999-214a-448a-a7f7-be447113785e"
+    },
+    {
+      "SourceParentOrChildId": "244a53c5-1261-44aa-89a4-13316e18efaf",
+      "SourceSlotId": "9dd9dbeb-b506-4d10-97b7-34feaab91f07",
+      "TargetParentOrChildId": "7dcb5f73-b565-4c42-b0b5-4089951481e0",
+      "TargetSlotId": "abaa52e9-7d3d-4ae5-89d2-5251f61e5392"
+    },
+    {
+      "SourceParentOrChildId": "51020cfd-c08d-49d7-b088-26fcfa549e4d",
+      "SourceSlotId": "7a4c4feb-be2f-463e-96c6-cd9a6bad77a2",
+      "TargetParentOrChildId": "7dcb5f73-b565-4c42-b0b5-4089951481e0",
+      "TargetSlotId": "c7c524cf-e31e-4bac-8f77-58bd61b337de"
+    },
+    {
+      "SourceParentOrChildId": "7e530b71-92dc-4dbc-a4a3-bfd039a35788",
+      "SourceSlotId": "e5dc2cd0-c57f-4e72-9452-e162fe1c37d5",
+      "TargetParentOrChildId": "b58bbea3-7b0d-4da9-9f77-db2ea51a1dcd",
+      "TargetSlotId": "565ff364-c3d9-4c60-a9a0-79fdd36d3477"
+    },
+    {
+      "SourceParentOrChildId": "b58bbea3-7b0d-4da9-9f77-db2ea51a1dcd",
+      "SourceSlotId": "ba17981e-ef9f-46f1-a653-6d50affa8838",
+      "TargetParentOrChildId": "ba6906c5-56b3-4bc8-a52e-f28930332f6d",
+      "TargetSlotId": "e15b6dc7-aaf9-4244-a4b8-4ac13ee7d23f"
+    },
+    {
+      "SourceParentOrChildId": "3d739213-68fd-4880-82d0-c3a265d44fc8",
+      "SourceSlotId": "97a91f72-1e40-412c-911e-70b142e16925",
+      "TargetParentOrChildId": "c39742ab-6ae0-427d-8206-a7a82281e101",
+      "TargetSlotId": "62949257-adb3-4c67-ac0a-d37ee28da81b"
+    },
+    {
+      "SourceParentOrChildId": "fd42e3c7-f346-4594-8ff7-38bed198000b",
+      "SourceSlotId": "977ca2f4-cddb-4b9a-82b2-ff66453bbf9b",
+      "TargetParentOrChildId": "e84b8af2-00ae-46ab-9d5c-b99320291b2b",
+      "TargetSlotId": "047b8fae-468c-48a7-8f3a-5fac8dd5b3c6"
+    },
+    {
+      "SourceParentOrChildId": "11633d13-d6af-4157-a6f8-7a17177a20bd",
+      "SourceSlotId": "d80e1028-a48d-4171-8c8c-e6856bd2143d",
+      "TargetParentOrChildId": "fd42e3c7-f346-4594-8ff7-38bed198000b",
+      "TargetSlotId": "9e961f73-1ee7-4369-9ac7-5c653e570b6f"
+    },
+    {
+      "SourceParentOrChildId": "ba6906c5-56b3-4bc8-a52e-f28930332f6d",
+      "SourceSlotId": "73ebf863-ba71-421c-bee7-312f13c5eff0",
+      "TargetParentOrChildId": "fd42e3c7-f346-4594-8ff7-38bed198000b",
+      "TargetSlotId": "9e961f73-1ee7-4369-9ac7-5c653e570b6f"
+    },
+    {
+      "SourceParentOrChildId": "e84b8af2-00ae-46ab-9d5c-b99320291b2b",
+      "SourceSlotId": "2e1742d8-9ba3-4236-a0cd-a2b02c9f5924",
+      "TargetParentOrChildId": "fddaebf7-f580-41c2-9670-d484ae751bb1",
+      "TargetSlotId": "4da253b7-4953-439a-b03f-1d515a78bddf"
+    }
+  ]
+}

--- a/Operators/Types/examples/lib/3d/mesh/UVsViewerExample_70e97e6b-3ddf-4a88-b080-c63fdbd251c9.t3ui
+++ b/Operators/Types/examples/lib/3d/mesh/UVsViewerExample_70e97e6b-3ddf-4a88-b080-c63fdbd251c9.t3ui
@@ -1,0 +1,213 @@
+{
+  "Id": "70e97e6b-3ddf-4a88-b080-c63fdbd251c9"/*UVsViewerExample*/,
+  "Description": "",
+  "InputUis": [],
+  "SymbolChildUis": [
+    {
+      "ChildId": "1561965d-0885-4f00-9a50-b669f78ea80a"/*UVsViewer*/,
+      "Comment": "Morph between the mesh's vertices position in 3D space to their UV coordinates position",
+      "Position": {
+        "X": 703.2556,
+        "Y": 109.617676
+      }
+    },
+    {
+      "ChildId": "80414f93-388e-4d5d-a2e3-dc542d4d51ac"/*SphereMesh*/,
+      "Position": {
+        "X": 93.05803,
+        "Y": 131.63298
+      }
+    },
+    {
+      "ChildId": "173781a9-55aa-4412-bfd0-75db58a79d89"/*DrawMesh*/,
+      "Position": {
+        "X": 986.63806,
+        "Y": 164.18726
+      }
+    },
+    {
+      "ChildId": "11633d13-d6af-4157-a6f8-7a17177a20bd"/*SetMaterial*/,
+      "Position": {
+        "X": 1136.6381,
+        "Y": 164.18726
+      }
+    },
+    {
+      "ChildId": "244a53c5-1261-44aa-89a4-13316e18efaf"/*CheckerBoard*/,
+      "Position": {
+        "X": 440.96707,
+        "Y": 405.74954
+      }
+    },
+    {
+      "ChildId": "3d739213-68fd-4880-82d0-c3a265d44fc8"/*UVmap*/,
+      "Position": {
+        "X": 401.43018,
+        "Y": 158.23315
+      }
+    },
+    {
+      "ChildId": "c39742ab-6ae0-427d-8206-a7a82281e101"/*TriggerAnim*/,
+      "Position": {
+        "X": 551.4302,
+        "Y": 158.23315
+      }
+    },
+    {
+      "ChildId": "fad09e3f-6564-4c70-9802-5618999c24c3"/*TorusMesh*/,
+      "Position": {
+        "X": 93.05803,
+        "Y": 88.63396
+      }
+    },
+    {
+      "ChildId": "5a83a84f-5b2a-4028-b35d-b6c478632844"/*CylinderMesh*/,
+      "Position": {
+        "X": 93.05803,
+        "Y": 45.634205
+      }
+    },
+    {
+      "ChildId": "7e530b71-92dc-4dbc-a4a3-bfd039a35788"/*CommonPointSets*/,
+      "Position": {
+        "X": 358.37027,
+        "Y": 707.27466
+      }
+    },
+    {
+      "ChildId": "b58bbea3-7b0d-4da9-9f77-db2ea51a1dcd"/*TransformPoints*/,
+      "Position": {
+        "X": 508.3702,
+        "Y": 707.27466
+      }
+    },
+    {
+      "ChildId": "ba6906c5-56b3-4bc8-a52e-f28930332f6d"/*DrawLines*/,
+      "Position": {
+        "X": 658.37024,
+        "Y": 707.27466
+      }
+    },
+    {
+      "ChildId": "e84b8af2-00ae-46ab-9d5c-b99320291b2b"/*Camera*/,
+      "Position": {
+        "X": 1436.6381,
+        "Y": 164.18726
+      }
+    },
+    {
+      "ChildId": "fddaebf7-f580-41c2-9670-d484ae751bb1"/*RenderTarget*/,
+      "Position": {
+        "X": 1586.6381,
+        "Y": 164.18726
+      }
+    },
+    {
+      "ChildId": "ba6343aa-25e0-41a9-8fbe-76aa35147bfc"/*Text*/,
+      "Position": {
+        "X": 231.5823,
+        "Y": 522.8589
+      }
+    },
+    {
+      "ChildId": "51020cfd-c08d-49d7-b088-26fcfa549e4d"/*RenderTarget*/,
+      "Position": {
+        "X": 440.60477,
+        "Y": 554.8926
+      }
+    },
+    {
+      "ChildId": "7dcb5f73-b565-4c42-b0b5-4089951481e0"/*Blend*/,
+      "Position": {
+        "X": 663.58575,
+        "Y": 477.04593
+      }
+    },
+    {
+      "ChildId": "6ad219dc-2b77-42e7-8503-eab6882d3125"/*PickMeshBuffer*/,
+      "Position": {
+        "X": 248.29199,
+        "Y": 76.62695
+      }
+    },
+    {
+      "ChildId": "b5bb5ebd-7663-40d8-9116-71181ad681cf"/*LoadObj*/,
+      "Position": {
+        "X": 93.05803,
+        "Y": 174.63249
+      }
+    },
+    {
+      "ChildId": "fd42e3c7-f346-4594-8ff7-38bed198000b"/*Group*/,
+      "Position": {
+        "X": 1286.6381,
+        "Y": 164.18726
+      }
+    }
+  ],
+  "OutputUis": [
+    {
+      "OutputId": "7c291a16-1e48-40c6-9fbc-cab14bb80720"/*ColorBuffer*/,
+      "Position": {
+        "X": 1736.6381,
+        "Y": 164.18726
+      }
+    }
+  ],
+  "Annotations": [
+    {
+      "Id": "ba59092d-42c5-4029-b147-5bca372433b7",
+      "Title": "Represents the area of the UV coordinates",
+      "Color": {
+        "X": 0.7092199,
+        "Y": 0.5583221,
+        "Z": 0.0,
+        "W": 1.0
+      },
+      "Position": {
+        "X": 298.37027,
+        "Y": 647.27466
+      },
+      "Size": {
+        "X": 530.0,
+        "Y": 156.0
+      }
+    },
+    {
+      "Id": "34042f0b-29c3-41d0-b05e-bd3e3ffcaa91",
+      "Title": "Switch between 3D and 2D UV map ",
+      "Color": {
+        "X": 0.6,
+        "Y": 0.6,
+        "Z": 0.6,
+        "W": 1.0
+      },
+      "Position": {
+        "X": 398.292,
+        "Y": 76.62695
+      },
+      "Size": {
+        "X": 435.16028,
+        "Y": 149.17554
+      }
+    },
+    {
+      "Id": "83171f3e-915a-4e18-b09a-f3d310b94cf6",
+      "Title": "Edit your texture",
+      "Color": {
+        "X": 0.7446804,
+        "Y": 0.0,
+        "Z": 1.0,
+        "W": 1.0
+      },
+      "Position": {
+        "X": 171.5823,
+        "Y": 246.81032
+      },
+      "Size": {
+        "X": 660.29767,
+        "Y": 378.49454
+      }
+    }
+  ]
+}

--- a/Operators/Types/lib/3d/mesh/generate/CylinderMesh.cs
+++ b/Operators/Types/lib/3d/mesh/generate/CylinderMesh.cs
@@ -188,8 +188,8 @@ namespace T3.Operators.Types.Id_5777a005_bbae_48d6_b633_5e998ca76c91
 
                                 // Write vertex
                                 var capUvOffset = isLowerCap 
-                                                      ? new Vector2(-0.25f, -0.25f)
-                                                      : new Vector2(0.25f, -0.25f);
+                                                      ? new Vector2(0.25f, 0.75f)
+                                                      : new Vector2(0.75f, 0.75f);
                                 
                                 p = Vector3.TransformNormal(p, rotationMatrix);                                
                                 _vertexBufferData[vertexIndex] = new PbrVertex

--- a/Operators/Types/lib/point/combine/UvsViewer.cs
+++ b/Operators/Types/lib/point/combine/UvsViewer.cs
@@ -4,45 +4,19 @@ using T3.Core.Operator.Slots;
 
 namespace T3.Operators.Types.Id_68cf773d_30ac_4ae0_bc1e_b7a17ea322bb
 {
-    public class UvsViewer : Instance<UvsViewer>
+    public class UVsViewer : Instance<UVsViewer>
     {
 
         [Output(Guid = "6ac1d050-592c-4533-9b5e-c9e62884c992")]
         public readonly Slot<T3.Core.DataTypes.MeshBuffers> BlendedMesh = new();
 
         [Input(Guid = "4ccfb3fe-5c64-45d6-8b3f-63249c69e146")]
-        public readonly InputSlot<T3.Core.DataTypes.MeshBuffers> MeshA = new InputSlot<T3.Core.DataTypes.MeshBuffers>();
+        public readonly InputSlot<T3.Core.DataTypes.MeshBuffers> Mesh = new InputSlot<T3.Core.DataTypes.MeshBuffers>();
 
         [Input(Guid = "017cf5d0-5e39-480e-9a23-ce3d6e1c0d40")]
         public readonly InputSlot<float> BlendValue = new InputSlot<float>();
 
-        [Input(Guid = "09a187f9-1a96-4d1c-84be-522061af7e49")]
-        public readonly InputSlot<float> Scatter = new InputSlot<float>();
-
-        [Input(Guid = "0d249c59-d48b-4329-9ad0-fb009e90a700", MappedType = typeof(BlendModes))]
-        public readonly InputSlot<int> BlendMode = new InputSlot<int>();
-
-        [Input(Guid = "3efbc6d9-8386-4160-8510-d4dcd4da37d6")]
-        public readonly InputSlot<float> RangeWidth = new InputSlot<float>();
-
-        [Input(Guid = "3bb4a7d7-f101-478b-ad99-1bfe3418179e", MappedType = typeof(PairingModes))]
-        public readonly InputSlot<int> Pairing = new InputSlot<int>();
-
-        
-        private enum BlendModes
-        {
-            Blend,
-            UseW1AsWeight,
-            UseW2AsWeight,
-            RangeBlend,
-            RangeBlendSmooth,
-        }
-        
-        private enum PairingModes
-        {
-            WrapAround,
-            Adjust,
-        }
+              
         
     }
 } 

--- a/Operators/Types/lib/point/combine/UvsViewer.cs
+++ b/Operators/Types/lib/point/combine/UvsViewer.cs
@@ -1,0 +1,49 @@
+using T3.Core.Operator;
+using T3.Core.Operator.Attributes;
+using T3.Core.Operator.Slots;
+
+namespace T3.Operators.Types.Id_68cf773d_30ac_4ae0_bc1e_b7a17ea322bb
+{
+    public class UvsViewer : Instance<UvsViewer>
+    {
+
+        [Output(Guid = "6ac1d050-592c-4533-9b5e-c9e62884c992")]
+        public readonly Slot<T3.Core.DataTypes.MeshBuffers> BlendedMesh = new();
+
+        [Input(Guid = "4ccfb3fe-5c64-45d6-8b3f-63249c69e146")]
+        public readonly InputSlot<T3.Core.DataTypes.MeshBuffers> MeshA = new InputSlot<T3.Core.DataTypes.MeshBuffers>();
+
+        [Input(Guid = "017cf5d0-5e39-480e-9a23-ce3d6e1c0d40")]
+        public readonly InputSlot<float> BlendValue = new InputSlot<float>();
+
+        [Input(Guid = "09a187f9-1a96-4d1c-84be-522061af7e49")]
+        public readonly InputSlot<float> Scatter = new InputSlot<float>();
+
+        [Input(Guid = "0d249c59-d48b-4329-9ad0-fb009e90a700", MappedType = typeof(BlendModes))]
+        public readonly InputSlot<int> BlendMode = new InputSlot<int>();
+
+        [Input(Guid = "3efbc6d9-8386-4160-8510-d4dcd4da37d6")]
+        public readonly InputSlot<float> RangeWidth = new InputSlot<float>();
+
+        [Input(Guid = "3bb4a7d7-f101-478b-ad99-1bfe3418179e", MappedType = typeof(PairingModes))]
+        public readonly InputSlot<int> Pairing = new InputSlot<int>();
+
+        
+        private enum BlendModes
+        {
+            Blend,
+            UseW1AsWeight,
+            UseW2AsWeight,
+            RangeBlend,
+            RangeBlendSmooth,
+        }
+        
+        private enum PairingModes
+        {
+            WrapAround,
+            Adjust,
+        }
+        
+    }
+} 
+

--- a/Operators/Types/lib/point/combine/UvsViewer_68cf773d-30ac-4ae0-bc1e-b7a17ea322bb.t3
+++ b/Operators/Types/lib/point/combine/UvsViewer_68cf773d-30ac-4ae0-bc1e-b7a17ea322bb.t3
@@ -1,31 +1,15 @@
 {
-  "Name": "UvsViewer",
+  "Name": "UVsViewer",
   "Id": "68cf773d-30ac-4ae0-bc1e-b7a17ea322bb",
   "Namespace": "lib.point.combine",
   "Inputs": [
     {
-      "Id": "4ccfb3fe-5c64-45d6-8b3f-63249c69e146"/*MeshA*/,
+      "Id": "4ccfb3fe-5c64-45d6-8b3f-63249c69e146"/*Mesh*/,
       "DefaultValue": null
     },
     {
       "Id": "017cf5d0-5e39-480e-9a23-ce3d6e1c0d40"/*BlendValue*/,
-      "DefaultValue": 0.5
-    },
-    {
-      "Id": "09a187f9-1a96-4d1c-84be-522061af7e49"/*Scatter*/,
-      "DefaultValue": 0.0
-    },
-    {
-      "Id": "0d249c59-d48b-4329-9ad0-fb009e90a700"/*BlendMode*/,
-      "DefaultValue": 0
-    },
-    {
-      "Id": "3efbc6d9-8386-4160-8510-d4dcd4da37d6"/*RangeWidth*/,
-      "DefaultValue": 0.5
-    },
-    {
-      "Id": "3bb4a7d7-f101-478b-ad99-1bfe3418179e"/*Pairing*/,
-      "DefaultValue": 0
+      "DefaultValue": 1.0
     }
   ],
   "Children": [
@@ -64,12 +48,6 @@
       "Outputs": []
     },
     {
-      "Id": "215732b2-a09e-4815-909a-2f22d8263dc0"/*IntToFloat*/,
-      "SymbolId": "17db8a36-079d-4c83-8a2a-7ea4c1aa49e6",
-      "InputValues": [],
-      "Outputs": []
-    },
-    {
       "Id": "79c5934f-6e73-4e4f-b569-1ba3a47cc6e8"/*ExecuteBufferUpdate*/,
       "SymbolId": "58351c8f-4a73-448e-b7bb-69412e71bd76",
       "InputValues": [],
@@ -100,19 +78,7 @@
       "Outputs": []
     },
     {
-      "Id": "e7e7ab7a-a176-4595-b894-e58cb4ed5530"/*IntToFloat*/,
-      "SymbolId": "17db8a36-079d-4c83-8a2a-7ea4c1aa49e6",
-      "InputValues": [],
-      "Outputs": []
-    },
-    {
       "Id": "d1b12e3f-af1f-4d86-a487-0f8fe3640c9c"/*_MeshBufferComponents*/,
-      "SymbolId": "5b9f1d97-4e10-4f31-ba83-4cbf7be9719b",
-      "InputValues": [],
-      "Outputs": []
-    },
-    {
-      "Id": "4a0298b3-a054-4e80-b768-b09de4408c8d"/*_MeshBufferComponents*/,
       "SymbolId": "5b9f1d97-4e10-4f31-ba83-4cbf7be9719b",
       "InputValues": [],
       "Outputs": []
@@ -147,12 +113,6 @@
         }
       ],
       "Outputs": []
-    },
-    {
-      "Id": "94605985-2f92-4ce7-ae70-1502c0f9674b"/*GetBufferComponents*/,
-      "SymbolId": "80dff680-5abf-484a-b9e0-81d72f3b7aa4",
-      "InputValues": [],
-      "Outputs": []
     }
   ],
   "Connections": [
@@ -173,12 +133,6 @@
       "SourceSlotId": "431b39fd-4b62-478b-bbfa-4346102c3f61",
       "TargetParentOrChildId": "030d2aed-000e-4582-a9a6-5e14f5eb004f",
       "TargetSlotId": "f79ccc37-05fd-4f81-97d6-6c1cafca180c"
-    },
-    {
-      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
-      "SourceSlotId": "0d249c59-d48b-4329-9ad0-fb009e90a700",
-      "TargetParentOrChildId": "215732b2-a09e-4815-909a-2f22d8263dc0",
-      "TargetSlotId": "01809b63-4b4a-47be-9588-98d5998ddb0c"
     },
     {
       "SourceParentOrChildId": "f099591b-b654-47a9-a6f9-4c7a51af70f7",
@@ -229,38 +183,8 @@
       "TargetSlotId": "72cfe742-88fb-41cd-b6cf-d96730b24b23"
     },
     {
-      "SourceParentOrChildId": "4a0298b3-a054-4e80-b768-b09de4408c8d",
-      "SourceSlotId": "0c5e2ec1-ab60-43ce-b823-3df096ff9a28",
-      "TargetParentOrChildId": "94605985-2f92-4ce7-ae70-1502c0f9674b",
-      "TargetSlotId": "7a13b834-21e5-4cef-ad5b-23c3770ea763"
-    },
-    {
       "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
       "SourceSlotId": "017cf5d0-5e39-480e-9a23-ce3d6e1c0d40",
-      "TargetParentOrChildId": "ac6f086a-b5b0-432c-be1a-5fbc4d266940",
-      "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
-    },
-    {
-      "SourceParentOrChildId": "215732b2-a09e-4815-909a-2f22d8263dc0",
-      "SourceSlotId": "db1073a1-b9d8-4d52-bc5c-7ae8c0ee1ac3",
-      "TargetParentOrChildId": "ac6f086a-b5b0-432c-be1a-5fbc4d266940",
-      "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
-    },
-    {
-      "SourceParentOrChildId": "e7e7ab7a-a176-4595-b894-e58cb4ed5530",
-      "SourceSlotId": "db1073a1-b9d8-4d52-bc5c-7ae8c0ee1ac3",
-      "TargetParentOrChildId": "ac6f086a-b5b0-432c-be1a-5fbc4d266940",
-      "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
-    },
-    {
-      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
-      "SourceSlotId": "3efbc6d9-8386-4160-8510-d4dcd4da37d6",
-      "TargetParentOrChildId": "ac6f086a-b5b0-432c-be1a-5fbc4d266940",
-      "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
-    },
-    {
-      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
-      "SourceSlotId": "09a187f9-1a96-4d1c-84be-522061af7e49",
       "TargetParentOrChildId": "ac6f086a-b5b0-432c-be1a-5fbc4d266940",
       "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
     },
@@ -295,22 +219,10 @@
       "TargetSlotId": "88938b09-d5a7-437c-b6e1-48a5b375d756"
     },
     {
-      "SourceParentOrChildId": "94605985-2f92-4ce7-ae70-1502c0f9674b",
-      "SourceSlotId": "1368ab8e-d75e-429f-8ecd-0944f3ede9ab",
-      "TargetParentOrChildId": "c6f8c96f-32b4-41aa-8aae-a3e6eaac799f",
-      "TargetSlotId": "88938b09-d5a7-437c-b6e1-48a5b375d756"
-    },
-    {
       "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
       "SourceSlotId": "4ccfb3fe-5c64-45d6-8b3f-63249c69e146",
       "TargetParentOrChildId": "d1b12e3f-af1f-4d86-a487-0f8fe3640c9c",
       "TargetSlotId": "1b0b7587-de86-4fc4-be78-a21392e8aa9b"
-    },
-    {
-      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
-      "SourceSlotId": "3bb4a7d7-f101-478b-ad99-1bfe3418179e",
-      "TargetParentOrChildId": "e7e7ab7a-a176-4595-b894-e58cb4ed5530",
-      "TargetSlotId": "01809b63-4b4a-47be-9588-98d5998ddb0c"
     },
     {
       "SourceParentOrChildId": "42313d36-3c92-45a3-a29f-66f876c80ed4",

--- a/Operators/Types/lib/point/combine/UvsViewer_68cf773d-30ac-4ae0-bc1e-b7a17ea322bb.t3
+++ b/Operators/Types/lib/point/combine/UvsViewer_68cf773d-30ac-4ae0-bc1e-b7a17ea322bb.t3
@@ -1,0 +1,322 @@
+{
+  "Name": "UvsViewer",
+  "Id": "68cf773d-30ac-4ae0-bc1e-b7a17ea322bb",
+  "Namespace": "lib.point.combine",
+  "Inputs": [
+    {
+      "Id": "4ccfb3fe-5c64-45d6-8b3f-63249c69e146"/*MeshA*/,
+      "DefaultValue": null
+    },
+    {
+      "Id": "017cf5d0-5e39-480e-9a23-ce3d6e1c0d40"/*BlendValue*/,
+      "DefaultValue": 0.5
+    },
+    {
+      "Id": "09a187f9-1a96-4d1c-84be-522061af7e49"/*Scatter*/,
+      "DefaultValue": 0.0
+    },
+    {
+      "Id": "0d249c59-d48b-4329-9ad0-fb009e90a700"/*BlendMode*/,
+      "DefaultValue": 0
+    },
+    {
+      "Id": "3efbc6d9-8386-4160-8510-d4dcd4da37d6"/*RangeWidth*/,
+      "DefaultValue": 0.5
+    },
+    {
+      "Id": "3bb4a7d7-f101-478b-ad99-1bfe3418179e"/*Pairing*/,
+      "DefaultValue": 0
+    }
+  ],
+  "Children": [
+    {
+      "Id": "2a945cb8-4a42-4875-bc8b-a346c3a0720c"/*ComputeShader*/,
+      "SymbolId": "a256d70f-adb3-481d-a926-caf35bd3e64c",
+      "InputValues": [
+        {
+          "Id": "afb69c81-5063-4cb9-9d42-841b994b5ec0"/*Source*/,
+          "Type": "System.String",
+          "Value": "Resources\\lib\\3d\\mesh\\fx\\mesh-UVs.hlsl"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "c6f8c96f-32b4-41aa-8aae-a3e6eaac799f"/*ComputeShaderStage*/,
+      "SymbolId": "8bef116d-7d1c-4c1b-b902-25c1d5e925a9",
+      "InputValues": [
+        {
+          "Id": "180cae35-10e3-47f3-8191-f6ecea7d321c"/*Dispatch*/,
+          "Type": "T3.Core.DataTypes.Vector.Int3",
+          "Value": {
+            "X": 64,
+            "Y": 1,
+            "Z": 1
+          }
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "ac6f086a-b5b0-432c-be1a-5fbc4d266940"/*FloatsToBuffer*/,
+      "SymbolId": "724da755-2d0c-42ab-8335-8c88ec5fb078",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "215732b2-a09e-4815-909a-2f22d8263dc0"/*IntToFloat*/,
+      "SymbolId": "17db8a36-079d-4c83-8a2a-7ea4c1aa49e6",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "79c5934f-6e73-4e4f-b569-1ba3a47cc6e8"/*ExecuteBufferUpdate*/,
+      "SymbolId": "58351c8f-4a73-448e-b7bb-69412e71bd76",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "030d2aed-000e-4582-a9a6-5e14f5eb004f"/*CalcDispatchCount*/,
+      "SymbolId": "eb68addb-ec59-416f-8608-ff9d2319f3a3",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "3fa39d7f-886d-4dad-a1f3-50a3b6b488bf"/*StructuredBufferWithViews*/,
+      "SymbolId": "b6c5be1d-b133-45e9-a269-8047ea0d6ad7",
+      "InputValues": [
+        {
+          "Id": "0016dd87-8756-4a97-a0da-096e1a879c05"/*Stride*/,
+          "Type": "System.Int32",
+          "Value": 32
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "49fced3e-8906-492f-abc2-9c1667467fdb"/*GetBufferComponents*/,
+      "SymbolId": "80dff680-5abf-484a-b9e0-81d72f3b7aa4",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "e7e7ab7a-a176-4595-b894-e58cb4ed5530"/*IntToFloat*/,
+      "SymbolId": "17db8a36-079d-4c83-8a2a-7ea4c1aa49e6",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "d1b12e3f-af1f-4d86-a487-0f8fe3640c9c"/*_MeshBufferComponents*/,
+      "SymbolId": "5b9f1d97-4e10-4f31-ba83-4cbf7be9719b",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "4a0298b3-a054-4e80-b768-b09de4408c8d"/*_MeshBufferComponents*/,
+      "SymbolId": "5b9f1d97-4e10-4f31-ba83-4cbf7be9719b",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "6ac4cf12-3a8a-4e57-bf0a-267fcb834120"/*_AssembleMeshBuffers*/,
+      "SymbolId": "e0849edd-ea1b-4657-b22d-5aa646318aa8",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "42313d36-3c92-45a3-a29f-66f876c80ed4"/*GetBufferComponents*/,
+      "SymbolId": "80dff680-5abf-484a-b9e0-81d72f3b7aa4",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "ece03783-31ef-4057-a82d-cb980a3fcdc2"/*GetSRVProperties*/,
+      "SymbolId": "bc489196-9a30-4580-af6f-dc059f226da1",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "f099591b-b654-47a9-a6f9-4c7a51af70f7"/*VertexStride*/,
+      "SymbolId": "cc07b314-4582-4c2c-84b8-bb32f59fc09b",
+      "Name": "VertexStride",
+      "InputValues": [
+        {
+          "Id": "4515c98e-05bc-4186-8773-4d2b31a8c323"/*Int*/,
+          "Type": "System.Int32",
+          "Value": 64
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "94605985-2f92-4ce7-ae70-1502c0f9674b"/*GetBufferComponents*/,
+      "SymbolId": "80dff680-5abf-484a-b9e0-81d72f3b7aa4",
+      "InputValues": [],
+      "Outputs": []
+    }
+  ],
+  "Connections": [
+    {
+      "SourceParentOrChildId": "6ac4cf12-3a8a-4e57-bf0a-267fcb834120",
+      "SourceSlotId": "d71893dd-6ca2-4ab7-9e04-0bd7285eccfb",
+      "TargetParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "TargetSlotId": "6ac1d050-592c-4533-9b5e-c9e62884c992"
+    },
+    {
+      "SourceParentOrChildId": "2a945cb8-4a42-4875-bc8b-a346c3a0720c",
+      "SourceSlotId": "a6fe06e0-b6a9-463c-9e62-930c58b0a0a1",
+      "TargetParentOrChildId": "030d2aed-000e-4582-a9a6-5e14f5eb004f",
+      "TargetSlotId": "3979e440-7888-4249-9975-74b21c6b813c"
+    },
+    {
+      "SourceParentOrChildId": "ece03783-31ef-4057-a82d-cb980a3fcdc2",
+      "SourceSlotId": "431b39fd-4b62-478b-bbfa-4346102c3f61",
+      "TargetParentOrChildId": "030d2aed-000e-4582-a9a6-5e14f5eb004f",
+      "TargetSlotId": "f79ccc37-05fd-4f81-97d6-6c1cafca180c"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "0d249c59-d48b-4329-9ad0-fb009e90a700",
+      "TargetParentOrChildId": "215732b2-a09e-4815-909a-2f22d8263dc0",
+      "TargetSlotId": "01809b63-4b4a-47be-9588-98d5998ddb0c"
+    },
+    {
+      "SourceParentOrChildId": "f099591b-b654-47a9-a6f9-4c7a51af70f7",
+      "SourceSlotId": "8a65b34b-40be-4dbf-812c-d4c663464c7f",
+      "TargetParentOrChildId": "3fa39d7f-886d-4dad-a1f3-50a3b6b488bf",
+      "TargetSlotId": "0016dd87-8756-4a97-a0da-096e1a879c05"
+    },
+    {
+      "SourceParentOrChildId": "ece03783-31ef-4057-a82d-cb980a3fcdc2",
+      "SourceSlotId": "431b39fd-4b62-478b-bbfa-4346102c3f61",
+      "TargetParentOrChildId": "3fa39d7f-886d-4dad-a1f3-50a3b6b488bf",
+      "TargetSlotId": "16f98211-fe97-4235-b33a-ddbbd2b5997f"
+    },
+    {
+      "SourceParentOrChildId": "d1b12e3f-af1f-4d86-a487-0f8fe3640c9c",
+      "SourceSlotId": "0c5e2ec1-ab60-43ce-b823-3df096ff9a28",
+      "TargetParentOrChildId": "42313d36-3c92-45a3-a29f-66f876c80ed4",
+      "TargetSlotId": "7a13b834-21e5-4cef-ad5b-23c3770ea763"
+    },
+    {
+      "SourceParentOrChildId": "3fa39d7f-886d-4dad-a1f3-50a3b6b488bf",
+      "SourceSlotId": "c997268d-6709-49de-980e-64d7a47504f7",
+      "TargetParentOrChildId": "49fced3e-8906-492f-abc2-9c1667467fdb",
+      "TargetSlotId": "7a13b834-21e5-4cef-ad5b-23c3770ea763"
+    },
+    {
+      "SourceParentOrChildId": "d1b12e3f-af1f-4d86-a487-0f8fe3640c9c",
+      "SourceSlotId": "78c53086-bb28-4c58-8b51-42cfdf6620c4",
+      "TargetParentOrChildId": "6ac4cf12-3a8a-4e57-bf0a-267fcb834120",
+      "TargetSlotId": "892838c5-fa5a-418e-81d6-a3a523819324"
+    },
+    {
+      "SourceParentOrChildId": "79c5934f-6e73-4e4f-b569-1ba3a47cc6e8",
+      "SourceSlotId": "9a66687e-a834-452c-a652-ba1fc70c2c7b",
+      "TargetParentOrChildId": "6ac4cf12-3a8a-4e57-bf0a-267fcb834120",
+      "TargetSlotId": "ba53b274-62ca-40a2-b8d2-87d08f0bc259"
+    },
+    {
+      "SourceParentOrChildId": "c6f8c96f-32b4-41aa-8aae-a3e6eaac799f",
+      "SourceSlotId": "c382284f-7e37-4eb0-b284-bc735247f26b",
+      "TargetParentOrChildId": "79c5934f-6e73-4e4f-b569-1ba3a47cc6e8",
+      "TargetSlotId": "51110d89-083e-42b8-b566-87b144dfbed9"
+    },
+    {
+      "SourceParentOrChildId": "3fa39d7f-886d-4dad-a1f3-50a3b6b488bf",
+      "SourceSlotId": "c997268d-6709-49de-980e-64d7a47504f7",
+      "TargetParentOrChildId": "79c5934f-6e73-4e4f-b569-1ba3a47cc6e8",
+      "TargetSlotId": "72cfe742-88fb-41cd-b6cf-d96730b24b23"
+    },
+    {
+      "SourceParentOrChildId": "4a0298b3-a054-4e80-b768-b09de4408c8d",
+      "SourceSlotId": "0c5e2ec1-ab60-43ce-b823-3df096ff9a28",
+      "TargetParentOrChildId": "94605985-2f92-4ce7-ae70-1502c0f9674b",
+      "TargetSlotId": "7a13b834-21e5-4cef-ad5b-23c3770ea763"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "017cf5d0-5e39-480e-9a23-ce3d6e1c0d40",
+      "TargetParentOrChildId": "ac6f086a-b5b0-432c-be1a-5fbc4d266940",
+      "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
+    },
+    {
+      "SourceParentOrChildId": "215732b2-a09e-4815-909a-2f22d8263dc0",
+      "SourceSlotId": "db1073a1-b9d8-4d52-bc5c-7ae8c0ee1ac3",
+      "TargetParentOrChildId": "ac6f086a-b5b0-432c-be1a-5fbc4d266940",
+      "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
+    },
+    {
+      "SourceParentOrChildId": "e7e7ab7a-a176-4595-b894-e58cb4ed5530",
+      "SourceSlotId": "db1073a1-b9d8-4d52-bc5c-7ae8c0ee1ac3",
+      "TargetParentOrChildId": "ac6f086a-b5b0-432c-be1a-5fbc4d266940",
+      "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "3efbc6d9-8386-4160-8510-d4dcd4da37d6",
+      "TargetParentOrChildId": "ac6f086a-b5b0-432c-be1a-5fbc4d266940",
+      "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "09a187f9-1a96-4d1c-84be-522061af7e49",
+      "TargetParentOrChildId": "ac6f086a-b5b0-432c-be1a-5fbc4d266940",
+      "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
+    },
+    {
+      "SourceParentOrChildId": "030d2aed-000e-4582-a9a6-5e14f5eb004f",
+      "SourceSlotId": "35c0e513-812f-49e2-96fa-17541751c19b",
+      "TargetParentOrChildId": "c6f8c96f-32b4-41aa-8aae-a3e6eaac799f",
+      "TargetSlotId": "180cae35-10e3-47f3-8191-f6ecea7d321c"
+    },
+    {
+      "SourceParentOrChildId": "ac6f086a-b5b0-432c-be1a-5fbc4d266940",
+      "SourceSlotId": "f5531ffb-dbde-45d3-af2a-bd90bcbf3710",
+      "TargetParentOrChildId": "c6f8c96f-32b4-41aa-8aae-a3e6eaac799f",
+      "TargetSlotId": "34cf06fe-8f63-4f14-9c59-35a2c021b817"
+    },
+    {
+      "SourceParentOrChildId": "49fced3e-8906-492f-abc2-9c1667467fdb",
+      "SourceSlotId": "f03246a7-e39f-4a41-a0c3-22bc976a6000",
+      "TargetParentOrChildId": "c6f8c96f-32b4-41aa-8aae-a3e6eaac799f",
+      "TargetSlotId": "599384c2-bf6c-4953-be74-d363292ab1c7"
+    },
+    {
+      "SourceParentOrChildId": "2a945cb8-4a42-4875-bc8b-a346c3a0720c",
+      "SourceSlotId": "6c118567-8827-4422-86cc-4d4d00762d87",
+      "TargetParentOrChildId": "c6f8c96f-32b4-41aa-8aae-a3e6eaac799f",
+      "TargetSlotId": "5c0e9c96-9aba-4757-ae1f-cc50fb6173f1"
+    },
+    {
+      "SourceParentOrChildId": "42313d36-3c92-45a3-a29f-66f876c80ed4",
+      "SourceSlotId": "1368ab8e-d75e-429f-8ecd-0944f3ede9ab",
+      "TargetParentOrChildId": "c6f8c96f-32b4-41aa-8aae-a3e6eaac799f",
+      "TargetSlotId": "88938b09-d5a7-437c-b6e1-48a5b375d756"
+    },
+    {
+      "SourceParentOrChildId": "94605985-2f92-4ce7-ae70-1502c0f9674b",
+      "SourceSlotId": "1368ab8e-d75e-429f-8ecd-0944f3ede9ab",
+      "TargetParentOrChildId": "c6f8c96f-32b4-41aa-8aae-a3e6eaac799f",
+      "TargetSlotId": "88938b09-d5a7-437c-b6e1-48a5b375d756"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "4ccfb3fe-5c64-45d6-8b3f-63249c69e146",
+      "TargetParentOrChildId": "d1b12e3f-af1f-4d86-a487-0f8fe3640c9c",
+      "TargetSlotId": "1b0b7587-de86-4fc4-be78-a21392e8aa9b"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "3bb4a7d7-f101-478b-ad99-1bfe3418179e",
+      "TargetParentOrChildId": "e7e7ab7a-a176-4595-b894-e58cb4ed5530",
+      "TargetSlotId": "01809b63-4b4a-47be-9588-98d5998ddb0c"
+    },
+    {
+      "SourceParentOrChildId": "42313d36-3c92-45a3-a29f-66f876c80ed4",
+      "SourceSlotId": "1368ab8e-d75e-429f-8ecd-0944f3ede9ab",
+      "TargetParentOrChildId": "ece03783-31ef-4057-a82d-cb980a3fcdc2",
+      "TargetSlotId": "e79473f4-3fd2-467e-acda-b27ef7dae6a9"
+    }
+  ]
+}

--- a/Operators/Types/lib/point/combine/UvsViewer_68cf773d-30ac-4ae0-bc1e-b7a17ea322bb.t3ui
+++ b/Operators/Types/lib/point/combine/UvsViewer_68cf773d-30ac-4ae0-bc1e-b7a17ea322bb.t3ui
@@ -1,0 +1,180 @@
+{
+  "Id": "68cf773d-30ac-4ae0-bc1e-b7a17ea322bb"/*UvsViewer*/,
+  "Description": "",
+  "InputUis": [
+    {
+      "InputId": "4ccfb3fe-5c64-45d6-8b3f-63249c69e146"/*MeshA*/,
+      "Relevancy": "Required",
+      "Position": {
+        "X": -458.9133,
+        "Y": 1142.6947
+      }
+    },
+    {
+      "InputId": "017cf5d0-5e39-480e-9a23-ce3d6e1c0d40"/*BlendValue*/,
+      "Position": {
+        "X": -453.51883,
+        "Y": 769.64264
+      },
+      "Min": 0.0,
+      "Max": 1.0,
+      "Clamp": true
+    },
+    {
+      "InputId": "09a187f9-1a96-4d1c-84be-522061af7e49"/*Scatter*/,
+      "Position": {
+        "X": -452.91107,
+        "Y": 998.6807
+      }
+    },
+    {
+      "InputId": "0d249c59-d48b-4329-9ad0-fb009e90a700"/*BlendMode*/,
+      "Position": {
+        "X": -453.51883,
+        "Y": 814.64264
+      }
+    },
+    {
+      "InputId": "3efbc6d9-8386-4160-8510-d4dcd4da37d6"/*RangeWidth*/,
+      "Position": {
+        "X": -452.91107,
+        "Y": 953.6807
+      }
+    },
+    {
+      "InputId": "3bb4a7d7-f101-478b-ad99-1bfe3418179e"/*Pairing*/,
+      "Position": {
+        "X": -453.51883,
+        "Y": 859.64264
+      }
+    }
+  ],
+  "SymbolChildUis": [
+    {
+      "ChildId": "2a945cb8-4a42-4875-bc8b-a346c3a0720c"/*ComputeShader*/,
+      "Position": {
+        "X": 78.32962,
+        "Y": 853.56177
+      }
+    },
+    {
+      "ChildId": "c6f8c96f-32b4-41aa-8aae-a3e6eaac799f"/*ComputeShaderStage*/,
+      "Position": {
+        "X": 487.14108,
+        "Y": 868.1397
+      }
+    },
+    {
+      "ChildId": "ac6f086a-b5b0-432c-be1a-5fbc4d266940"/*FloatsToBuffer*/,
+      "Style": "Resizable",
+      "Size": {
+        "X": 110.86372,
+        "Y": 44.69636
+      },
+      "Position": {
+        "X": 298.73434,
+        "Y": 979.3921
+      }
+    },
+    {
+      "ChildId": "215732b2-a09e-4815-909a-2f22d8263dc0"/*IntToFloat*/,
+      "Position": {
+        "X": -323.51883,
+        "Y": 814.64264
+      }
+    },
+    {
+      "ChildId": "79c5934f-6e73-4e4f-b569-1ba3a47cc6e8"/*ExecuteBufferUpdate*/,
+      "Position": {
+        "X": 647.30347,
+        "Y": 1034.7814
+      }
+    },
+    {
+      "ChildId": "030d2aed-000e-4582-a9a6-5e14f5eb004f"/*CalcDispatchCount*/,
+      "Position": {
+        "X": 298.73434,
+        "Y": 910.3921
+      }
+    },
+    {
+      "ChildId": "3fa39d7f-886d-4dad-a1f3-50a3b6b488bf"/*StructuredBufferWithViews*/,
+      "Position": {
+        "X": 148.73434,
+        "Y": 1057.6326
+      }
+    },
+    {
+      "ChildId": "49fced3e-8906-492f-abc2-9c1667467fdb"/*GetBufferComponents*/,
+      "Position": {
+        "X": 298.73434,
+        "Y": 1022.3921
+      }
+    },
+    {
+      "ChildId": "e7e7ab7a-a176-4595-b894-e58cb4ed5530"/*IntToFloat*/,
+      "Position": {
+        "X": -323.51883,
+        "Y": 870.64264
+      }
+    },
+    {
+      "ChildId": "d1b12e3f-af1f-4d86-a487-0f8fe3640c9c"/*_MeshBufferComponents*/,
+      "Position": {
+        "X": -308.9133,
+        "Y": 1142.6947
+      }
+    },
+    {
+      "ChildId": "4a0298b3-a054-4e80-b768-b09de4408c8d"/*_MeshBufferComponents*/,
+      "Position": {
+        "X": -310.26855,
+        "Y": 1204.6438
+      }
+    },
+    {
+      "ChildId": "6ac4cf12-3a8a-4e57-bf0a-267fcb834120"/*_AssembleMeshBuffers*/,
+      "Position": {
+        "X": 797.30347,
+        "Y": 1034.7814
+      }
+    },
+    {
+      "ChildId": "42313d36-3c92-45a3-a29f-66f876c80ed4"/*GetBufferComponents*/,
+      "Position": {
+        "X": -151.26566,
+        "Y": 1100.6326
+      }
+    },
+    {
+      "ChildId": "ece03783-31ef-4057-a82d-cb980a3fcdc2"/*GetSRVProperties*/,
+      "Position": {
+        "X": -1.2656555,
+        "Y": 1100.6326
+      }
+    },
+    {
+      "ChildId": "f099591b-b654-47a9-a6f9-4c7a51af70f7"/*VertexStride*/,
+      "Position": {
+        "X": -1.2656555,
+        "Y": 1057.6326
+      }
+    },
+    {
+      "ChildId": "94605985-2f92-4ce7-ae70-1502c0f9674b"/*GetBufferComponents*/,
+      "Position": {
+        "X": -160.26855,
+        "Y": 1204.6438
+      }
+    }
+  ],
+  "OutputUis": [
+    {
+      "OutputId": "6ac1d050-592c-4533-9b5e-c9e62884c992"/*BlendedMesh*/,
+      "Position": {
+        "X": 947.30347,
+        "Y": 1034.7814
+      }
+    }
+  ]
+}

--- a/Operators/Types/lib/point/combine/UvsViewer_68cf773d-30ac-4ae0-bc1e-b7a17ea322bb.t3ui
+++ b/Operators/Types/lib/point/combine/UvsViewer_68cf773d-30ac-4ae0-bc1e-b7a17ea322bb.t3ui
@@ -1,52 +1,24 @@
 {
-  "Id": "68cf773d-30ac-4ae0-bc1e-b7a17ea322bb"/*UvsViewer*/,
-  "Description": "",
+  "Id": "68cf773d-30ac-4ae0-bc1e-b7a17ea322bb"/*UVsViewer*/,
+  "Description": "Morph a mesh to its UV map. It can be useful when you edit the texture of a mesh. \n\n[TransformMeshUVs] [MeshProjectUV]",
   "InputUis": [
     {
-      "InputId": "4ccfb3fe-5c64-45d6-8b3f-63249c69e146"/*MeshA*/,
+      "InputId": "4ccfb3fe-5c64-45d6-8b3f-63249c69e146"/*Mesh*/,
       "Relevancy": "Required",
       "Position": {
-        "X": -458.9133,
-        "Y": 1142.6947
+        "X": -493.16177,
+        "Y": 823.9202
       }
     },
     {
       "InputId": "017cf5d0-5e39-480e-9a23-ce3d6e1c0d40"/*BlendValue*/,
       "Position": {
-        "X": -453.51883,
-        "Y": 769.64264
+        "X": -485.13284,
+        "Y": 992.25793
       },
       "Min": 0.0,
       "Max": 1.0,
       "Clamp": true
-    },
-    {
-      "InputId": "09a187f9-1a96-4d1c-84be-522061af7e49"/*Scatter*/,
-      "Position": {
-        "X": -452.91107,
-        "Y": 998.6807
-      }
-    },
-    {
-      "InputId": "0d249c59-d48b-4329-9ad0-fb009e90a700"/*BlendMode*/,
-      "Position": {
-        "X": -453.51883,
-        "Y": 814.64264
-      }
-    },
-    {
-      "InputId": "3efbc6d9-8386-4160-8510-d4dcd4da37d6"/*RangeWidth*/,
-      "Position": {
-        "X": -452.91107,
-        "Y": 953.6807
-      }
-    },
-    {
-      "InputId": "3bb4a7d7-f101-478b-ad99-1bfe3418179e"/*Pairing*/,
-      "Position": {
-        "X": -453.51883,
-        "Y": 859.64264
-      }
     }
   ],
   "SymbolChildUis": [
@@ -73,14 +45,7 @@
       },
       "Position": {
         "X": 298.73434,
-        "Y": 979.3921
-      }
-    },
-    {
-      "ChildId": "215732b2-a09e-4815-909a-2f22d8263dc0"/*IntToFloat*/,
-      "Position": {
-        "X": -323.51883,
-        "Y": 814.64264
+        "Y": 966.3921
       }
     },
     {
@@ -112,24 +77,10 @@
       }
     },
     {
-      "ChildId": "e7e7ab7a-a176-4595-b894-e58cb4ed5530"/*IntToFloat*/,
-      "Position": {
-        "X": -323.51883,
-        "Y": 870.64264
-      }
-    },
-    {
       "ChildId": "d1b12e3f-af1f-4d86-a487-0f8fe3640c9c"/*_MeshBufferComponents*/,
       "Position": {
         "X": -308.9133,
         "Y": 1142.6947
-      }
-    },
-    {
-      "ChildId": "4a0298b3-a054-4e80-b768-b09de4408c8d"/*_MeshBufferComponents*/,
-      "Position": {
-        "X": -310.26855,
-        "Y": 1204.6438
       }
     },
     {
@@ -158,13 +109,6 @@
       "Position": {
         "X": -1.2656555,
         "Y": 1057.6326
-      }
-    },
-    {
-      "ChildId": "94605985-2f92-4ce7-ae70-1502c0f9674b"/*GetBufferComponents*/,
-      "Position": {
-        "X": -160.26855,
-        "Y": 1204.6438
       }
     }
   ],

--- a/Resources/lib/3d/mesh/fx/mesh-UVs.hlsl
+++ b/Resources/lib/3d/mesh/fx/mesh-UVs.hlsl
@@ -1,19 +1,15 @@
-#include "lib/shared/hash-functions.hlsl"
+//#include "lib/shared/hash-functions.hlsl"
 // #include "lib/shared/point.hlsl"
-#include "lib/shared/quat-functions.hlsl"
+//#include "lib/shared/quat-functions.hlsl"
 #include "lib/shared/pbr.hlsl"
 
 cbuffer Params : register(b0)
 {
     float BlendFactor;
-    float BlendMode;
-    float PairingMode;
-    float Width;
-    float Scatter;
 }
 
 StructuredBuffer<PbrVertex> VerticesA : t0;        // input
-StructuredBuffer<PbrVertex> VerticesB : t1;        // input
+
 RWStructuredBuffer<PbrVertex> ResultVertices : u0; // output
 
 [numthreads(64, 1, 1)] void main(uint3 i
@@ -22,64 +18,23 @@ RWStructuredBuffer<PbrVertex> ResultVertices : u0; // output
     uint resultCount, countA, countB, stride;
     ResultVertices.GetDimensions(resultCount, stride);
     VerticesA.GetDimensions(countA, stride);
-    VerticesB.GetDimensions(countB, stride);
+
 
     if (i.x > resultCount)
         return;
 
     uint aIndex = i.x;
-    uint bIndex = i.x;
 
     float t = i.x / (float)resultCount;
 
-    if (PairingMode > 0.5 && countA != countB)
-    {
-        aIndex = (int)(countA * t);
-        bIndex = (int)(countB * t);
-    }
-
     PbrVertex A = VerticesA[aIndex];
-    PbrVertex B = VerticesB[bIndex];
 
-    float f = 0;
-
-    if (BlendMode < 0.5)
-    {
-        f = BlendFactor;
-    }
-    else if (BlendMode < 1.5)
-    {
-        f = A.Selected;
-    }
-    else if (BlendMode < 2.5)
-    {
-        f = (1 - B.Selected);
-    }
-
-    // Ranged
-    // see https://www.desmos.com/calculator/zxs1fy06uh
-    else if (BlendMode < 3.5)
-    {
-        f = 1 - saturate((t - BlendFactor) / Width - BlendFactor + 1);
-    }
-    else
-    {
-        float b = BlendFactor % 2;
-        if (b > 1)
-        {
-            b = 2 - b;
-            t = 1 - t;
-        }
-        f = 1 - smoothstep(0, 1, saturate((t - b) / Width - b + 1));
-    }
-
-    float fallOffFromCenter = smoothstep(0, 1, 1 - abs(f - 0.5) * 2);
-    f += (hash11(t) - 0.5) * Scatter * fallOffFromCenter;
+    float f = BlendFactor;
 
     ResultVertices[i.x].Position = lerp(A.Position, float3(A.TexCoord,0) , f);
     ResultVertices[i.x].Normal = lerp(A.Normal,float3(0,0,1), f); 
     ResultVertices[i.x].Tangent = lerp(A.Tangent, float3(1,0,0), f);
     ResultVertices[i.x].Bitangent = lerp(A.Bitangent, float3(0,1,0), f);
     ResultVertices[i.x].TexCoord = A.TexCoord;
-    ResultVertices[i.x].Selected = lerp(A.Selected, B.Selected, f);
+    ResultVertices[i.x].Selected = A.Selected;
 }

--- a/Resources/lib/3d/mesh/fx/mesh-UVs.hlsl
+++ b/Resources/lib/3d/mesh/fx/mesh-UVs.hlsl
@@ -1,0 +1,85 @@
+#include "lib/shared/hash-functions.hlsl"
+// #include "lib/shared/point.hlsl"
+#include "lib/shared/quat-functions.hlsl"
+#include "lib/shared/pbr.hlsl"
+
+cbuffer Params : register(b0)
+{
+    float BlendFactor;
+    float BlendMode;
+    float PairingMode;
+    float Width;
+    float Scatter;
+}
+
+StructuredBuffer<PbrVertex> VerticesA : t0;        // input
+StructuredBuffer<PbrVertex> VerticesB : t1;        // input
+RWStructuredBuffer<PbrVertex> ResultVertices : u0; // output
+
+[numthreads(64, 1, 1)] void main(uint3 i
+                                 : SV_DispatchThreadID)
+{
+    uint resultCount, countA, countB, stride;
+    ResultVertices.GetDimensions(resultCount, stride);
+    VerticesA.GetDimensions(countA, stride);
+    VerticesB.GetDimensions(countB, stride);
+
+    if (i.x > resultCount)
+        return;
+
+    uint aIndex = i.x;
+    uint bIndex = i.x;
+
+    float t = i.x / (float)resultCount;
+
+    if (PairingMode > 0.5 && countA != countB)
+    {
+        aIndex = (int)(countA * t);
+        bIndex = (int)(countB * t);
+    }
+
+    PbrVertex A = VerticesA[aIndex];
+    PbrVertex B = VerticesB[bIndex];
+
+    float f = 0;
+
+    if (BlendMode < 0.5)
+    {
+        f = BlendFactor;
+    }
+    else if (BlendMode < 1.5)
+    {
+        f = A.Selected;
+    }
+    else if (BlendMode < 2.5)
+    {
+        f = (1 - B.Selected);
+    }
+
+    // Ranged
+    // see https://www.desmos.com/calculator/zxs1fy06uh
+    else if (BlendMode < 3.5)
+    {
+        f = 1 - saturate((t - BlendFactor) / Width - BlendFactor + 1);
+    }
+    else
+    {
+        float b = BlendFactor % 2;
+        if (b > 1)
+        {
+            b = 2 - b;
+            t = 1 - t;
+        }
+        f = 1 - smoothstep(0, 1, saturate((t - b) / Width - b + 1));
+    }
+
+    float fallOffFromCenter = smoothstep(0, 1, 1 - abs(f - 0.5) * 2);
+    f += (hash11(t) - 0.5) * Scatter * fallOffFromCenter;
+
+    ResultVertices[i.x].Position = lerp(A.Position, float3(A.TexCoord,0) , f);
+    ResultVertices[i.x].Normal = lerp(A.Normal,float3(0,0,1), f); 
+    ResultVertices[i.x].Tangent = lerp(A.Tangent, float3(1,0,0), f);
+    ResultVertices[i.x].Bitangent = lerp(A.Bitangent, float3(0,1,0), f);
+    ResultVertices[i.x].TexCoord = A.TexCoord;
+    ResultVertices[i.x].Selected = lerp(A.Selected, B.Selected, f);
+}


### PR DESCRIPTION
It's based on [BlendMeshVertices], but instead of blending from one mesh to an other it blends from the mesh to its UV coordinates.

While testing it on [CylinderMesh] it helped to see that all its UV islands were not inside the UV map area then I managed to edit CylinderMesh.CS in order to fix this. 

This video describes a use case and shows [CylinderMesh] UV map:
https://github.com/tooll3/t3/assets/3755089/31855c9c-d570-4bc7-aa9d-45a8fcf5a825

Here is the corrected UV map for [CylinderMesh]
![CynlinderMeshUVs](https://github.com/tooll3/t3/assets/3755089/352d2cf5-b02d-49a0-a028-640b7580d17a)


