### PR TITLE
Adds PlayAtlas and SnapToMultiple operators

### DIFF
--- a/Operators/Types/user/community/PlayAtlas.cs
+++ b/Operators/Types/user/community/PlayAtlas.cs
@@ -1,0 +1,40 @@
+using SharpDX.Direct3D11;
+using T3.Core.Operator;
+using T3.Core.Operator.Attributes;
+using T3.Core.Operator.Slots;
+
+namespace T3.Operators.Types.Id_9e243276_1807_49f7_9e78_29b582aafb39
+{
+    public class PlayAtlas : Instance<PlayAtlas>
+    {
+
+        [Input(Guid = "6bffaa67-be6d-43cc-9890-75d0a1c51d75")]
+        public readonly InputSlot<SharpDX.Direct3D11.Texture2D> Texture2d = new InputSlot<SharpDX.Direct3D11.Texture2D>();
+
+        [Input(Guid = "a47fc959-4ffa-4790-ac1f-5097a72fab3f")]
+        public readonly InputSlot<int> FrameCountX = new InputSlot<int>();
+
+        [Input(Guid = "25ac515f-2f7f-4ebf-9852-fc96bc83d6af")]
+        public readonly InputSlot<int> FrameCountY = new InputSlot<int>();
+
+        [Input(Guid = "65f7f342-fbe8-4fb3-9019-c891fa651d5d")]
+        public readonly InputSlot<int> FramesToTruncate = new InputSlot<int>();
+
+        [Input(Guid = "7304732c-ebfa-41d5-938c-f01ecc228749")]
+        public readonly InputSlot<bool> DisableSnapping = new InputSlot<bool>();
+
+        [Input(Guid = "3f7b1f1f-7790-4142-890c-c69a17689b87")]
+        public readonly InputSlot<int> StartFrame = new InputSlot<int>();
+
+        [Input(Guid = "69c0ee10-8498-4128-b865-7e622b62cd3d")]
+        public readonly InputSlot<float> PlaybackRate = new InputSlot<float>();
+
+        [Input(Guid = "21212842-58f4-424b-98c2-603423fead1f")]
+        public readonly InputSlot<float> FineDelay = new InputSlot<float>();
+
+        [Output(Guid = "372da297-6bb0-49fc-a92f-41bfcc5f9f1a")]
+        public readonly Slot<SharpDX.Direct3D11.Texture2D> output = new Slot<SharpDX.Direct3D11.Texture2D>();
+
+    }
+}
+

--- a/Operators/Types/user/community/PlayAtlas_9e243276-1807-49f7-9e78-29b582aafb39.t3
+++ b/Operators/Types/user/community/PlayAtlas_9e243276-1807-49f7-9e78-29b582aafb39.t3
@@ -1,0 +1,962 @@
+{
+  "Name": "PlayAtlas",
+  "Id": "9e243276-1807-49f7-9e78-29b582aafb39",
+  "Namespace": "user.community",
+  "Inputs": [
+    {
+      "Id": "6bffaa67-be6d-43cc-9890-75d0a1c51d75"/*Texture2d*/,
+      "DefaultValue": null
+    },
+    {
+      "Id": "a47fc959-4ffa-4790-ac1f-5097a72fab3f"/*FrameCountX*/,
+      "DefaultValue": 0
+    },
+    {
+      "Id": "25ac515f-2f7f-4ebf-9852-fc96bc83d6af"/*FrameCountY*/,
+      "DefaultValue": 0
+    },
+    {
+      "Id": "65f7f342-fbe8-4fb3-9019-c891fa651d5d"/*FramesToTruncate*/,
+      "DefaultValue": 0
+    },
+    {
+      "Id": "7304732c-ebfa-41d5-938c-f01ecc228749"/*DisableSnapping*/,
+      "DefaultValue": false
+    },
+    {
+      "Id": "3f7b1f1f-7790-4142-890c-c69a17689b87"/*StartFrame*/,
+      "DefaultValue": 0
+    },
+    {
+      "Id": "69c0ee10-8498-4128-b865-7e622b62cd3d"/*PlaybackRate*/,
+      "DefaultValue": 0.0
+    },
+    {
+      "Id": "21212842-58f4-424b-98c2-603423fead1f"/*FineDelay*/,
+      "DefaultValue": 0.0
+    }
+  ],
+  "Children": [
+    {
+      "Id": "13e983a5-3b45-454f-96ba-88903bb653fe"/*Crop*/,
+      "SymbolId": "a29cf1c8-d9cd-4a5d-b06c-597cbeb5b33d",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "d5706230-af1a-425a-996e-f4e9d710968e"/*IntValue*/,
+      "SymbolId": "cc07b314-4582-4c2c-84b8-bb32f59fc09b",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "f8ceece9-fc01-49e7-a0d7-8cf7eaa2db67"/*IntValue*/,
+      "SymbolId": "cc07b314-4582-4c2c-84b8-bb32f59fc09b",
+      "InputValues": [
+        {
+          "Id": "4515c98e-05bc-4186-8773-4d2b31a8c323"/*Int*/,
+          "Type": "System.Int32",
+          "Value": 5
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "04386033-c5d5-42f7-8403-aa131f3eb1c5"/*GetTextureSize*/,
+      "SymbolId": "daec568f-f7b4-4d81-a401-34d62462daab",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "f092d8ae-80d4-4b7b-ac28-90a848784147"/*Int2Components*/,
+      "SymbolId": "f86358e0-2573-4acd-9a90-e95108e8a4da",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "a17d35a6-4b7b-4839-86db-53e6da087c81"/*ClampInt*/,
+      "SymbolId": "5f734c25-9f1a-436c-b56c-7e0a1e07fdda",
+      "InputValues": [
+        {
+          "Id": "e715919d-f3e3-4708-90a6-b55efb379257"/*Min*/,
+          "Type": "System.Int32",
+          "Value": 1
+        },
+        {
+          "Id": "23e55b5d-b469-4d0f-a495-7e87fe65cccf"/*Max*/,
+          "Type": "System.Int32",
+          "Value": 11700000
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "824ce6c4-be43-40ae-a65f-e1cf80bf16e1"/*Int2*/,
+      "SymbolId": "f1218934-f874-4f70-a077-0ebe7d12104d",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "7e3da07b-e9fb-412a-94b6-3903dd4a4880"/*IntDiv*/,
+      "SymbolId": "eae8b8af-ce79-4e0a-9777-2dd0a99c18cb",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "700f1d29-bb96-476e-8e7e-666b4faad7ea"/*SubInts*/,
+      "SymbolId": "7934f11d-c95c-41ae-b282-6e568b9c5f30",
+      "InputValues": [
+        {
+          "Id": "b1a34f4a-7be5-4c6b-84f1-0bb04cc80d0d"/*Input2*/,
+          "Type": "System.Int32",
+          "Value": 1
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "4a14118a-74c5-4f48-ad69-e0215b6b6c6b"/*MultiplyInt*/,
+      "SymbolId": "6a4edb6a-5ced-4356-9090-4bf770cdeb52",
+      "InputValues": [
+        {
+          "Id": "e02f9e84-a7bf-45bf-9cb1-0b0c1c396796"/*B*/,
+          "Type": "System.Int32",
+          "Value": 11
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "d5ea7059-bcb5-4a8a-8af3-e2a7c1f3c34b"/*MultiplyInt*/,
+      "SymbolId": "6a4edb6a-5ced-4356-9090-4bf770cdeb52",
+      "InputValues": [
+        {
+          "Id": "e02f9e84-a7bf-45bf-9cb1-0b0c1c396796"/*B*/,
+          "Type": "System.Int32",
+          "Value": -1
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "6b5d582a-7766-4dfb-9bd6-5ef9d8dd1aac"/*AddInts*/,
+      "SymbolId": "ab73a49e-c548-437d-a4ab-b3fa41e30097",
+      "InputValues": [
+        {
+          "Id": "d5efbe02-8f33-42e9-a205-859c218acbec"/*Input2*/,
+          "Type": "System.Int32",
+          "Value": 1
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "c6adaa8e-714b-409b-9cb6-dd80c46ce278"/*MultiplyInt*/,
+      "SymbolId": "6a4edb6a-5ced-4356-9090-4bf770cdeb52",
+      "InputValues": [
+        {
+          "Id": "e02f9e84-a7bf-45bf-9cb1-0b0c1c396796"/*B*/,
+          "Type": "System.Int32",
+          "Value": 11
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "5f70e665-df3c-4a35-a713-5afc39d3d488"/*ModInt*/,
+      "SymbolId": "cf3268d7-4f3d-47bd-8cb5-0214c75432ec",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "82b7c2fe-56d3-4194-8813-7532777c257a"/*MaxInt*/,
+      "SymbolId": "f7fd7342-18d1-443a-98ec-758974891434",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "a1fe5622-1a68-4601-857c-0b3b7c186a1e"/*IntValue*/,
+      "SymbolId": "cc07b314-4582-4c2c-84b8-bb32f59fc09b",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "fe5c9a54-b124-4bde-af9a-640c06cbf3d4"/*PickInt*/,
+      "SymbolId": "81555155-ae6f-40aa-961d-b6badb77af21",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "27858375-373c-4374-8ac9-f0f93875380c"/*BoolToInt*/,
+      "SymbolId": "cd43942a-887e-4e34-bc54-0c2e5e8bc2af",
+      "InputValues": [
+        {
+          "Id": "9b64f287-d14a-493e-a1c7-dcbcdc703849"/*ResultForFalse*/,
+          "Type": "System.Int32",
+          "Value": 1
+        },
+        {
+          "Id": "cbbb6b8a-0dc9-4a85-8abc-e4c9c1c9c8be"/*ResultForTrue*/,
+          "Type": "System.Int32",
+          "Value": 0
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "561fa13e-cb2b-470b-b50f-e363b9bf0f6c"/*IntValue*/,
+      "SymbolId": "cc07b314-4582-4c2c-84b8-bb32f59fc09b",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "e859a80f-73e6-404f-8028-93acf66f3235"/*ClampInt*/,
+      "SymbolId": "5f734c25-9f1a-436c-b56c-7e0a1e07fdda",
+      "InputValues": [
+        {
+          "Id": "e715919d-f3e3-4708-90a6-b55efb379257"/*Min*/,
+          "Type": "System.Int32",
+          "Value": 1
+        },
+        {
+          "Id": "23e55b5d-b469-4d0f-a495-7e87fe65cccf"/*Max*/,
+          "Type": "System.Int32",
+          "Value": 11700000
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "4afe5445-6d8f-4165-b97b-7415f29c6ac8"/*IntDiv*/,
+      "SymbolId": "eae8b8af-ce79-4e0a-9777-2dd0a99c18cb",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "580e3af2-7af4-40f0-a0a1-15051f9f208c"/*PickInt*/,
+      "SymbolId": "81555155-ae6f-40aa-961d-b6badb77af21",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "42a89bc0-e86e-4683-b9c2-92a793f183b1"/*BoolToInt*/,
+      "SymbolId": "cd43942a-887e-4e34-bc54-0c2e5e8bc2af",
+      "InputValues": [
+        {
+          "Id": "9b64f287-d14a-493e-a1c7-dcbcdc703849"/*ResultForFalse*/,
+          "Type": "System.Int32",
+          "Value": 1
+        },
+        {
+          "Id": "cbbb6b8a-0dc9-4a85-8abc-e4c9c1c9c8be"/*ResultForTrue*/,
+          "Type": "System.Int32",
+          "Value": 0
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "1e5c43bf-da7f-4ff9-939c-7cdc28858fa8"/*SubInts*/,
+      "SymbolId": "7934f11d-c95c-41ae-b282-6e568b9c5f30",
+      "InputValues": [
+        {
+          "Id": "b1a34f4a-7be5-4c6b-84f1-0bb04cc80d0d"/*Input2*/,
+          "Type": "System.Int32",
+          "Value": 1
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "c6b532a3-af49-4921-9834-fed35229a44b"/*MultiplyInt*/,
+      "SymbolId": "6a4edb6a-5ced-4356-9090-4bf770cdeb52",
+      "InputValues": [
+        {
+          "Id": "e02f9e84-a7bf-45bf-9cb1-0b0c1c396796"/*B*/,
+          "Type": "System.Int32",
+          "Value": 11
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "68056aa6-31d3-4479-8447-e5ccd9b12e24"/*MultiplyInt*/,
+      "SymbolId": "6a4edb6a-5ced-4356-9090-4bf770cdeb52",
+      "InputValues": [
+        {
+          "Id": "e02f9e84-a7bf-45bf-9cb1-0b0c1c396796"/*B*/,
+          "Type": "System.Int32",
+          "Value": -1
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "c92ce97c-6d3f-4a56-b805-ab05abe12438"/*AddInts*/,
+      "SymbolId": "ab73a49e-c548-437d-a4ab-b3fa41e30097",
+      "InputValues": [
+        {
+          "Id": "d5efbe02-8f33-42e9-a205-859c218acbec"/*Input2*/,
+          "Type": "System.Int32",
+          "Value": 1
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "ef29d038-64df-433c-b318-b8e0e4a70703"/*MultiplyInt*/,
+      "SymbolId": "6a4edb6a-5ced-4356-9090-4bf770cdeb52",
+      "InputValues": [
+        {
+          "Id": "e02f9e84-a7bf-45bf-9cb1-0b0c1c396796"/*B*/,
+          "Type": "System.Int32",
+          "Value": 11
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "c26cbb4e-82c8-40f5-8f1c-b8cff4257071"/*ModInt*/,
+      "SymbolId": "cf3268d7-4f3d-47bd-8cb5-0214c75432ec",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "2c2ab357-a955-4a11-a60f-d0228ad3601d"/*Int2*/,
+      "SymbolId": "f1218934-f874-4f70-a077-0ebe7d12104d",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "28126558-fff8-4114-bacb-ea556909c6cd"/*IntDiv*/,
+      "SymbolId": "eae8b8af-ce79-4e0a-9777-2dd0a99c18cb",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "74833d7b-dbaf-48b2-b246-1037f4239a4b"/*MultiplyInt*/,
+      "SymbolId": "6a4edb6a-5ced-4356-9090-4bf770cdeb52",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "99f16266-04a0-4fe9-a088-74451f6ce130"/*SubInts*/,
+      "SymbolId": "7934f11d-c95c-41ae-b282-6e568b9c5f30",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "69c19c6c-4285-463e-a1cf-e16b1885f666"/*ModInt*/,
+      "SymbolId": "cf3268d7-4f3d-47bd-8cb5-0214c75432ec",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "b9073aa9-6186-4ff4-8ea1-f5903c910726"/*AnimValue*/,
+      "SymbolId": "ea7b8491-2f8e-4add-b0b1-fd068ccfed0d",
+      "InputValues": [
+        {
+          "Id": "48005727-0158-4795-ad70-8410c27fd01d"/*Rate*/,
+          "Type": "System.Single",
+          "Value": 0.1
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "c34fc007-5c8d-4f95-9d08-66bc0f07fed2"/*IntToFloat*/,
+      "SymbolId": "17db8a36-079d-4c83-8a2a-7ea4c1aa49e6",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "39d005dc-6169-4468-bcd8-87a0e6053aaa"/*Floor*/,
+      "SymbolId": "55b13dee-89f8-404f-b2fe-43d5e8c54536",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "9dc00663-f34f-4996-a2ec-96c974277ed1"/*FloatToInt*/,
+      "SymbolId": "06b4728e-852c-491a-a89d-647f7e0b5415",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "618853ef-3f49-4dd9-aafa-a9dabace62ef"/*SubInts*/,
+      "SymbolId": "7934f11d-c95c-41ae-b282-6e568b9c5f30",
+      "InputValues": [
+        {
+          "Id": "b1a34f4a-7be5-4c6b-84f1-0bb04cc80d0d"/*Input2*/,
+          "Type": "System.Int32",
+          "Value": 1
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "1d7dde02-cfdc-42b2-953e-ad4cb3ec8cff"/*SubInts*/,
+      "SymbolId": "7934f11d-c95c-41ae-b282-6e568b9c5f30",
+      "InputValues": [
+        {
+          "Id": "b1a34f4a-7be5-4c6b-84f1-0bb04cc80d0d"/*Input2*/,
+          "Type": "System.Int32",
+          "Value": -1
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "2e138248-d920-4813-9db7-3d44126e0313"/*SubInts*/,
+      "SymbolId": "7934f11d-c95c-41ae-b282-6e568b9c5f30",
+      "InputValues": [
+        {
+          "Id": "b1a34f4a-7be5-4c6b-84f1-0bb04cc80d0d"/*Input2*/,
+          "Type": "System.Int32",
+          "Value": -1
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "d4071a33-0bc5-4dce-8dee-4db0563e8b09"/*SubInts*/,
+      "SymbolId": "7934f11d-c95c-41ae-b282-6e568b9c5f30",
+      "InputValues": [
+        {
+          "Id": "b1a34f4a-7be5-4c6b-84f1-0bb04cc80d0d"/*Input2*/,
+          "Type": "System.Int32",
+          "Value": 1
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "03686acc-a185-4e57-97cd-075736dccc86"/*AddInts*/,
+      "SymbolId": "ab73a49e-c548-437d-a4ab-b3fa41e30097",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "7f3ef40e-4dee-4653-92df-bd4029327144"/*Value*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "28ca4d22-2f39-4c4d-ad10-0fde310c14fb"/*IntValue*/,
+      "SymbolId": "cc07b314-4582-4c2c-84b8-bb32f59fc09b",
+      "InputValues": [
+        {
+          "Id": "4515c98e-05bc-4186-8773-4d2b31a8c323"/*Int*/,
+          "Type": "System.Int32",
+          "Value": 2240
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "1677c88f-79e5-4c01-b702-4aff1990f1be"/*IntValue*/,
+      "SymbolId": "cc07b314-4582-4c2c-84b8-bb32f59fc09b",
+      "InputValues": [
+        {
+          "Id": "4515c98e-05bc-4186-8773-4d2b31a8c323"/*Int*/,
+          "Type": "System.Int32",
+          "Value": 56
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "1f08c22a-aafd-4c61-ac9a-2737b6f72bff"/*IntValue*/,
+      "SymbolId": "cc07b314-4582-4c2c-84b8-bb32f59fc09b",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "f758e789-eb94-42b6-b5db-948651f69ae5"/*IterateList*/,
+      "SymbolId": "8b285708-3f20-4957-9eb2-bb40e0d320ee",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "67f0ca8e-d1d3-4fbe-9719-a91191d48689"/*ModInt*/,
+      "SymbolId": "cf3268d7-4f3d-47bd-8cb5-0214c75432ec",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "62c9f8a8-efad-4f5d-92cd-fe0cd178e195"/*SnapToMultiple*/,
+      "SymbolId": "c3090c65-194a-4f95-9b70-d003f54103f7",
+      "InputValues": [
+        {
+          "Id": "3bf35135-8fb1-46d3-95ea-008eded67060"/*Value*/,
+          "Type": "System.Int32",
+          "Value": 2240
+        },
+        {
+          "Id": "e122bf1d-8455-43f6-867f-4f43f3d6533c"/*Mod*/,
+          "Type": "System.Int32",
+          "Value": 120
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "a8b4f066-1e93-42e8-a7fb-0951a422a85b"/*SnapToMultiple*/,
+      "SymbolId": "c3090c65-194a-4f95-9b70-d003f54103f7",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "532e59d9-f633-46b8-9ca9-c9d4710a76ec"/*SnapToMultiple*/,
+      "SymbolId": "c3090c65-194a-4f95-9b70-d003f54103f7",
+      "InputValues": [],
+      "Outputs": []
+    }
+  ],
+  "Connections": [
+    {
+      "SourceParentOrChildId": "13e983a5-3b45-454f-96ba-88903bb653fe",
+      "SourceSlotId": "0f7a4421-97d7-48d0-8a99-a7cc84356be2",
+      "TargetParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "TargetSlotId": "372da297-6bb0-49fc-a92f-41bfcc5f9f1a"
+    },
+    {
+      "SourceParentOrChildId": "82b7c2fe-56d3-4194-8813-7532777c257a",
+      "SourceSlotId": "0b6a3094-e7b3-4b61-a1d9-f220de67720a",
+      "TargetParentOrChildId": "03686acc-a185-4e57-97cd-075736dccc86",
+      "TargetSlotId": "8496877c-6186-4a9f-acb2-ceb90026dc1d"
+    },
+    {
+      "SourceParentOrChildId": "9dc00663-f34f-4996-a2ec-96c974277ed1",
+      "SourceSlotId": "1eb7c5c4-0982-43f4-b14d-524571e3cdda",
+      "TargetParentOrChildId": "03686acc-a185-4e57-97cd-075736dccc86",
+      "TargetSlotId": "d5efbe02-8f33-42e9-a205-859c218acbec"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "6bffaa67-be6d-43cc-9890-75d0a1c51d75",
+      "TargetParentOrChildId": "04386033-c5d5-42f7-8403-aa131f3eb1c5",
+      "TargetSlotId": "8b15d8e1-10c7-41e1-84db-a85e31e0c909"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "6bffaa67-be6d-43cc-9890-75d0a1c51d75",
+      "TargetParentOrChildId": "13e983a5-3b45-454f-96ba-88903bb653fe",
+      "TargetSlotId": "a7fff052-42c2-40fb-938e-9fb9b6cfa591"
+    },
+    {
+      "SourceParentOrChildId": "2c2ab357-a955-4a11-a60f-d0228ad3601d",
+      "SourceSlotId": "3265ff5f-9d8d-48d5-a6f8-9085b4f19a78",
+      "TargetParentOrChildId": "13e983a5-3b45-454f-96ba-88903bb653fe",
+      "TargetSlotId": "db4c2d41-c369-4182-83fd-cb04aa04ec76"
+    },
+    {
+      "SourceParentOrChildId": "824ce6c4-be43-40ae-a65f-e1cf80bf16e1",
+      "SourceSlotId": "3265ff5f-9d8d-48d5-a6f8-9085b4f19a78",
+      "TargetParentOrChildId": "13e983a5-3b45-454f-96ba-88903bb653fe",
+      "TargetSlotId": "eff02108-2335-46b5-95ba-4235b9a26349"
+    },
+    {
+      "SourceParentOrChildId": "4a14118a-74c5-4f48-ad69-e0215b6b6c6b",
+      "SourceSlotId": "5e847363-142d-4da9-a5b3-3a7aa2541bed",
+      "TargetParentOrChildId": "1d7dde02-cfdc-42b2-953e-ad4cb3ec8cff",
+      "TargetSlotId": "944152fb-3786-4474-90ea-c292b5dde801"
+    },
+    {
+      "SourceParentOrChildId": "580e3af2-7af4-40f0-a0a1-15051f9f208c",
+      "SourceSlotId": "9ddd1c52-865a-4930-84ec-98d3c0ffaa9c",
+      "TargetParentOrChildId": "1e5c43bf-da7f-4ff9-939c-7cdc28858fa8",
+      "TargetSlotId": "944152fb-3786-4474-90ea-c292b5dde801"
+    },
+    {
+      "SourceParentOrChildId": "c92ce97c-6d3f-4a56-b805-ab05abe12438",
+      "SourceSlotId": "9b3e42f6-8980-4f30-8d8f-ed1dea5f19b9",
+      "TargetParentOrChildId": "1e5c43bf-da7f-4ff9-939c-7cdc28858fa8",
+      "TargetSlotId": "b1a34f4a-7be5-4c6b-84f1-0bb04cc80d0d"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "7304732c-ebfa-41d5-938c-f01ecc228749",
+      "TargetParentOrChildId": "27858375-373c-4374-8ac9-f0f93875380c",
+      "TargetSlotId": "c644165f-3901-4dbf-8091-05f958e668e5"
+    },
+    {
+      "SourceParentOrChildId": "f8ceece9-fc01-49e7-a0d7-8cf7eaa2db67",
+      "SourceSlotId": "8a65b34b-40be-4dbf-812c-d4c663464c7f",
+      "TargetParentOrChildId": "28126558-fff8-4114-bacb-ea556909c6cd",
+      "TargetSlotId": "95aaaa60-5582-40b0-907d-74a39710c006"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "a47fc959-4ffa-4790-ac1f-5097a72fab3f",
+      "TargetParentOrChildId": "28126558-fff8-4114-bacb-ea556909c6cd",
+      "TargetSlotId": "996cc728-62ab-4c77-b454-59f0d2f25c00"
+    },
+    {
+      "SourceParentOrChildId": "2e138248-d920-4813-9db7-3d44126e0313",
+      "SourceSlotId": "e66c9218-06dc-4e8d-9f30-9d81f22e39ba",
+      "TargetParentOrChildId": "2c2ab357-a955-4a11-a60f-d0228ad3601d",
+      "TargetSlotId": "53602af2-48d9-42ab-80c3-ae1f1e600d28"
+    },
+    {
+      "SourceParentOrChildId": "d4071a33-0bc5-4dce-8dee-4db0563e8b09",
+      "SourceSlotId": "e66c9218-06dc-4e8d-9f30-9d81f22e39ba",
+      "TargetParentOrChildId": "2c2ab357-a955-4a11-a60f-d0228ad3601d",
+      "TargetSlotId": "579e72d6-638e-4b17-bb4e-88a55e3a1d4d"
+    },
+    {
+      "SourceParentOrChildId": "c6b532a3-af49-4921-9834-fed35229a44b",
+      "SourceSlotId": "5e847363-142d-4da9-a5b3-3a7aa2541bed",
+      "TargetParentOrChildId": "2e138248-d920-4813-9db7-3d44126e0313",
+      "TargetSlotId": "944152fb-3786-4474-90ea-c292b5dde801"
+    },
+    {
+      "SourceParentOrChildId": "b9073aa9-6186-4ff4-8ea1-f5903c910726",
+      "SourceSlotId": "ae4addf0-08cf-4b25-9515-4fef9359d183",
+      "TargetParentOrChildId": "39d005dc-6169-4468-bcd8-87a0e6053aaa",
+      "TargetSlotId": "550289db-89cb-465c-a9d8-a16dbf23cc45"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "7304732c-ebfa-41d5-938c-f01ecc228749",
+      "TargetParentOrChildId": "42a89bc0-e86e-4683-b9c2-92a793f183b1",
+      "TargetSlotId": "c644165f-3901-4dbf-8091-05f958e668e5"
+    },
+    {
+      "SourceParentOrChildId": "d5ea7059-bcb5-4a8a-8af3-e2a7c1f3c34b",
+      "SourceSlotId": "5e847363-142d-4da9-a5b3-3a7aa2541bed",
+      "TargetParentOrChildId": "4a14118a-74c5-4f48-ad69-e0215b6b6c6b",
+      "TargetSlotId": "e010c56f-ff0b-44b6-bbd9-b50e2ccec2bf"
+    },
+    {
+      "SourceParentOrChildId": "700f1d29-bb96-476e-8e7e-666b4faad7ea",
+      "SourceSlotId": "e66c9218-06dc-4e8d-9f30-9d81f22e39ba",
+      "TargetParentOrChildId": "4a14118a-74c5-4f48-ad69-e0215b6b6c6b",
+      "TargetSlotId": "e02f9e84-a7bf-45bf-9cb1-0b0c1c396796"
+    },
+    {
+      "SourceParentOrChildId": "f092d8ae-80d4-4b7b-ac28-90a848784147",
+      "SourceSlotId": "dc835127-e03b-4afa-b91a-468781b5b599",
+      "TargetParentOrChildId": "4afe5445-6d8f-4165-b97b-7415f29c6ac8",
+      "TargetSlotId": "95aaaa60-5582-40b0-907d-74a39710c006"
+    },
+    {
+      "SourceParentOrChildId": "580e3af2-7af4-40f0-a0a1-15051f9f208c",
+      "SourceSlotId": "9ddd1c52-865a-4930-84ec-98d3c0ffaa9c",
+      "TargetParentOrChildId": "4afe5445-6d8f-4165-b97b-7415f29c6ac8",
+      "TargetSlotId": "996cc728-62ab-4c77-b454-59f0d2f25c00"
+    },
+    {
+      "SourceParentOrChildId": "f092d8ae-80d4-4b7b-ac28-90a848784147",
+      "SourceSlotId": "dc835127-e03b-4afa-b91a-468781b5b599",
+      "TargetParentOrChildId": "532e59d9-f633-46b8-9ca9-c9d4710a76ec",
+      "TargetSlotId": "3bf35135-8fb1-46d3-95ea-008eded67060"
+    },
+    {
+      "SourceParentOrChildId": "561fa13e-cb2b-470b-b50f-e363b9bf0f6c",
+      "SourceSlotId": "8a65b34b-40be-4dbf-812c-d4c663464c7f",
+      "TargetParentOrChildId": "532e59d9-f633-46b8-9ca9-c9d4710a76ec",
+      "TargetSlotId": "e122bf1d-8455-43f6-867f-4f43f3d6533c"
+    },
+    {
+      "SourceParentOrChildId": "e859a80f-73e6-404f-8028-93acf66f3235",
+      "SourceSlotId": "e6aae72f-8c22-4133-ba0d-c3635751d715",
+      "TargetParentOrChildId": "561fa13e-cb2b-470b-b50f-e363b9bf0f6c",
+      "TargetSlotId": "4515c98e-05bc-4186-8773-4d2b31a8c323"
+    },
+    {
+      "SourceParentOrChildId": "561fa13e-cb2b-470b-b50f-e363b9bf0f6c",
+      "SourceSlotId": "8a65b34b-40be-4dbf-812c-d4c663464c7f",
+      "TargetParentOrChildId": "580e3af2-7af4-40f0-a0a1-15051f9f208c",
+      "TargetSlotId": "2c0a4eb2-da56-449d-91b8-5ba0870fbeb4"
+    },
+    {
+      "SourceParentOrChildId": "532e59d9-f633-46b8-9ca9-c9d4710a76ec",
+      "SourceSlotId": "87a311ce-238c-472c-b43e-e4ed5268bbc5",
+      "TargetParentOrChildId": "580e3af2-7af4-40f0-a0a1-15051f9f208c",
+      "TargetSlotId": "2c0a4eb2-da56-449d-91b8-5ba0870fbeb4"
+    },
+    {
+      "SourceParentOrChildId": "42a89bc0-e86e-4683-b9c2-92a793f183b1",
+      "SourceSlotId": "b0cfa6f9-3c3d-4499-b21a-5904d1cb3bd7",
+      "TargetParentOrChildId": "580e3af2-7af4-40f0-a0a1-15051f9f208c",
+      "TargetSlotId": "8bbc412b-f574-4a2b-9cbc-bf4f60aebb17"
+    },
+    {
+      "SourceParentOrChildId": "f8ceece9-fc01-49e7-a0d7-8cf7eaa2db67",
+      "SourceSlotId": "8a65b34b-40be-4dbf-812c-d4c663464c7f",
+      "TargetParentOrChildId": "5f70e665-df3c-4a35-a713-5afc39d3d488",
+      "TargetSlotId": "3528f4d3-3529-4551-9dc1-e1dafe6b0669"
+    },
+    {
+      "SourceParentOrChildId": "fe5c9a54-b124-4bde-af9a-640c06cbf3d4",
+      "SourceSlotId": "9ddd1c52-865a-4930-84ec-98d3c0ffaa9c",
+      "TargetParentOrChildId": "5f70e665-df3c-4a35-a713-5afc39d3d488",
+      "TargetSlotId": "ccdea113-c046-4ec2-b1fb-30d6e15db7ce"
+    },
+    {
+      "SourceParentOrChildId": "c6adaa8e-714b-409b-9cb6-dd80c46ce278",
+      "SourceSlotId": "5e847363-142d-4da9-a5b3-3a7aa2541bed",
+      "TargetParentOrChildId": "618853ef-3f49-4dd9-aafa-a9dabace62ef",
+      "TargetSlotId": "944152fb-3786-4474-90ea-c292b5dde801"
+    },
+    {
+      "SourceParentOrChildId": "4afe5445-6d8f-4165-b97b-7415f29c6ac8",
+      "SourceSlotId": "3bb1068a-04ef-4804-83f8-3a3ee6922e2f",
+      "TargetParentOrChildId": "68056aa6-31d3-4479-8447-e5ccd9b12e24",
+      "TargetSlotId": "e010c56f-ff0b-44b6-bbd9-b50e2ccec2bf"
+    },
+    {
+      "SourceParentOrChildId": "03686acc-a185-4e57-97cd-075736dccc86",
+      "SourceSlotId": "9b3e42f6-8980-4f30-8d8f-ed1dea5f19b9",
+      "TargetParentOrChildId": "69c19c6c-4285-463e-a1cf-e16b1885f666",
+      "TargetSlotId": "3528f4d3-3529-4551-9dc1-e1dafe6b0669"
+    },
+    {
+      "SourceParentOrChildId": "99f16266-04a0-4fe9-a088-74451f6ce130",
+      "SourceSlotId": "e66c9218-06dc-4e8d-9f30-9d81f22e39ba",
+      "TargetParentOrChildId": "69c19c6c-4285-463e-a1cf-e16b1885f666",
+      "TargetSlotId": "ccdea113-c046-4ec2-b1fb-30d6e15db7ce"
+    },
+    {
+      "SourceParentOrChildId": "5f70e665-df3c-4a35-a713-5afc39d3d488",
+      "SourceSlotId": "8fed46e4-b9df-4d56-b098-9c9a17775139",
+      "TargetParentOrChildId": "6b5d582a-7766-4dfb-9bd6-5ef9d8dd1aac",
+      "TargetSlotId": "8496877c-6186-4a9f-acb2-ceb90026dc1d"
+    },
+    {
+      "SourceParentOrChildId": "fe5c9a54-b124-4bde-af9a-640c06cbf3d4",
+      "SourceSlotId": "9ddd1c52-865a-4930-84ec-98d3c0ffaa9c",
+      "TargetParentOrChildId": "700f1d29-bb96-476e-8e7e-666b4faad7ea",
+      "TargetSlotId": "944152fb-3786-4474-90ea-c292b5dde801"
+    },
+    {
+      "SourceParentOrChildId": "6b5d582a-7766-4dfb-9bd6-5ef9d8dd1aac",
+      "SourceSlotId": "9b3e42f6-8980-4f30-8d8f-ed1dea5f19b9",
+      "TargetParentOrChildId": "700f1d29-bb96-476e-8e7e-666b4faad7ea",
+      "TargetSlotId": "b1a34f4a-7be5-4c6b-84f1-0bb04cc80d0d"
+    },
+    {
+      "SourceParentOrChildId": "fe5c9a54-b124-4bde-af9a-640c06cbf3d4",
+      "SourceSlotId": "9ddd1c52-865a-4930-84ec-98d3c0ffaa9c",
+      "TargetParentOrChildId": "74833d7b-dbaf-48b2-b246-1037f4239a4b",
+      "TargetSlotId": "e010c56f-ff0b-44b6-bbd9-b50e2ccec2bf"
+    },
+    {
+      "SourceParentOrChildId": "580e3af2-7af4-40f0-a0a1-15051f9f208c",
+      "SourceSlotId": "9ddd1c52-865a-4930-84ec-98d3c0ffaa9c",
+      "TargetParentOrChildId": "74833d7b-dbaf-48b2-b246-1037f4239a4b",
+      "TargetSlotId": "e02f9e84-a7bf-45bf-9cb1-0b0c1c396796"
+    },
+    {
+      "SourceParentOrChildId": "f092d8ae-80d4-4b7b-ac28-90a848784147",
+      "SourceSlotId": "cd0bd085-dd4a-46a5-bf00-39a199434b30",
+      "TargetParentOrChildId": "7e3da07b-e9fb-412a-94b6-3903dd4a4880",
+      "TargetSlotId": "95aaaa60-5582-40b0-907d-74a39710c006"
+    },
+    {
+      "SourceParentOrChildId": "fe5c9a54-b124-4bde-af9a-640c06cbf3d4",
+      "SourceSlotId": "9ddd1c52-865a-4930-84ec-98d3c0ffaa9c",
+      "TargetParentOrChildId": "7e3da07b-e9fb-412a-94b6-3903dd4a4880",
+      "TargetSlotId": "996cc728-62ab-4c77-b454-59f0d2f25c00"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "21212842-58f4-424b-98c2-603423fead1f",
+      "TargetParentOrChildId": "7f3ef40e-4dee-4653-92df-bd4029327144",
+      "TargetSlotId": "7773837e-104a-4b3d-a41f-cadbd9249af2"
+    },
+    {
+      "SourceParentOrChildId": "1d7dde02-cfdc-42b2-953e-ad4cb3ec8cff",
+      "SourceSlotId": "e66c9218-06dc-4e8d-9f30-9d81f22e39ba",
+      "TargetParentOrChildId": "824ce6c4-be43-40ae-a65f-e1cf80bf16e1",
+      "TargetSlotId": "53602af2-48d9-42ab-80c3-ae1f1e600d28"
+    },
+    {
+      "SourceParentOrChildId": "618853ef-3f49-4dd9-aafa-a9dabace62ef",
+      "SourceSlotId": "e66c9218-06dc-4e8d-9f30-9d81f22e39ba",
+      "TargetParentOrChildId": "824ce6c4-be43-40ae-a65f-e1cf80bf16e1",
+      "TargetSlotId": "579e72d6-638e-4b17-bb4e-88a55e3a1d4d"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "3f7b1f1f-7790-4142-890c-c69a17689b87",
+      "TargetParentOrChildId": "82b7c2fe-56d3-4194-8813-7532777c257a",
+      "TargetSlotId": "286dacdf-a469-4983-a944-d9f34ed1e7de"
+    },
+    {
+      "SourceParentOrChildId": "a1fe5622-1a68-4601-857c-0b3b7c186a1e",
+      "SourceSlotId": "8a65b34b-40be-4dbf-812c-d4c663464c7f",
+      "TargetParentOrChildId": "82b7c2fe-56d3-4194-8813-7532777c257a",
+      "TargetSlotId": "286dacdf-a469-4983-a944-d9f34ed1e7de"
+    },
+    {
+      "SourceParentOrChildId": "74833d7b-dbaf-48b2-b246-1037f4239a4b",
+      "SourceSlotId": "5e847363-142d-4da9-a5b3-3a7aa2541bed",
+      "TargetParentOrChildId": "99f16266-04a0-4fe9-a088-74451f6ce130",
+      "TargetSlotId": "944152fb-3786-4474-90ea-c292b5dde801"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "65f7f342-fbe8-4fb3-9019-c891fa651d5d",
+      "TargetParentOrChildId": "99f16266-04a0-4fe9-a088-74451f6ce130",
+      "TargetSlotId": "b1a34f4a-7be5-4c6b-84f1-0bb04cc80d0d"
+    },
+    {
+      "SourceParentOrChildId": "39d005dc-6169-4468-bcd8-87a0e6053aaa",
+      "SourceSlotId": "5c54174b-c9e6-41de-b796-84ef4271dd20",
+      "TargetParentOrChildId": "9dc00663-f34f-4996-a2ec-96c974277ed1",
+      "TargetSlotId": "af866a6c-1ab0-43c0-9e8a-5d25c300e128"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "a47fc959-4ffa-4790-ac1f-5097a72fab3f",
+      "TargetParentOrChildId": "a17d35a6-4b7b-4839-86db-53e6da087c81",
+      "TargetSlotId": "75a09454-6cde-458b-9314-05a99b2e5919"
+    },
+    {
+      "SourceParentOrChildId": "f092d8ae-80d4-4b7b-ac28-90a848784147",
+      "SourceSlotId": "cd0bd085-dd4a-46a5-bf00-39a199434b30",
+      "TargetParentOrChildId": "a8b4f066-1e93-42e8-a7fb-0951a422a85b",
+      "TargetSlotId": "3bf35135-8fb1-46d3-95ea-008eded67060"
+    },
+    {
+      "SourceParentOrChildId": "d5706230-af1a-425a-996e-f4e9d710968e",
+      "SourceSlotId": "8a65b34b-40be-4dbf-812c-d4c663464c7f",
+      "TargetParentOrChildId": "a8b4f066-1e93-42e8-a7fb-0951a422a85b",
+      "TargetSlotId": "e122bf1d-8455-43f6-867f-4f43f3d6533c"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "69c0ee10-8498-4128-b865-7e622b62cd3d",
+      "TargetParentOrChildId": "b9073aa9-6186-4ff4-8ea1-f5903c910726",
+      "TargetSlotId": "48005727-0158-4795-ad70-8410c27fd01d"
+    },
+    {
+      "SourceParentOrChildId": "7f3ef40e-4dee-4653-92df-bd4029327144",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "b9073aa9-6186-4ff4-8ea1-f5903c910726",
+      "TargetSlotId": "68f14205-f48d-4b44-823d-138eb61767b5"
+    },
+    {
+      "SourceParentOrChildId": "c34fc007-5c8d-4f95-9d08-66bc0f07fed2",
+      "SourceSlotId": "db1073a1-b9d8-4d52-bc5c-7ae8c0ee1ac3",
+      "TargetParentOrChildId": "b9073aa9-6186-4ff4-8ea1-f5903c910726",
+      "TargetSlotId": "79917ef7-64ca-4825-9c6a-c9b2a7f6ff86"
+    },
+    {
+      "SourceParentOrChildId": "28126558-fff8-4114-bacb-ea556909c6cd",
+      "SourceSlotId": "3bb1068a-04ef-4804-83f8-3a3ee6922e2f",
+      "TargetParentOrChildId": "c26cbb4e-82c8-40f5-8f1c-b8cff4257071",
+      "TargetSlotId": "3528f4d3-3529-4551-9dc1-e1dafe6b0669"
+    },
+    {
+      "SourceParentOrChildId": "580e3af2-7af4-40f0-a0a1-15051f9f208c",
+      "SourceSlotId": "9ddd1c52-865a-4930-84ec-98d3c0ffaa9c",
+      "TargetParentOrChildId": "c26cbb4e-82c8-40f5-8f1c-b8cff4257071",
+      "TargetSlotId": "ccdea113-c046-4ec2-b1fb-30d6e15db7ce"
+    },
+    {
+      "SourceParentOrChildId": "99f16266-04a0-4fe9-a088-74451f6ce130",
+      "SourceSlotId": "e66c9218-06dc-4e8d-9f30-9d81f22e39ba",
+      "TargetParentOrChildId": "c34fc007-5c8d-4f95-9d08-66bc0f07fed2",
+      "TargetSlotId": "01809b63-4b4a-47be-9588-98d5998ddb0c"
+    },
+    {
+      "SourceParentOrChildId": "d5ea7059-bcb5-4a8a-8af3-e2a7c1f3c34b",
+      "SourceSlotId": "5e847363-142d-4da9-a5b3-3a7aa2541bed",
+      "TargetParentOrChildId": "c6adaa8e-714b-409b-9cb6-dd80c46ce278",
+      "TargetSlotId": "e010c56f-ff0b-44b6-bbd9-b50e2ccec2bf"
+    },
+    {
+      "SourceParentOrChildId": "5f70e665-df3c-4a35-a713-5afc39d3d488",
+      "SourceSlotId": "8fed46e4-b9df-4d56-b098-9c9a17775139",
+      "TargetParentOrChildId": "c6adaa8e-714b-409b-9cb6-dd80c46ce278",
+      "TargetSlotId": "e02f9e84-a7bf-45bf-9cb1-0b0c1c396796"
+    },
+    {
+      "SourceParentOrChildId": "68056aa6-31d3-4479-8447-e5ccd9b12e24",
+      "SourceSlotId": "5e847363-142d-4da9-a5b3-3a7aa2541bed",
+      "TargetParentOrChildId": "c6b532a3-af49-4921-9834-fed35229a44b",
+      "TargetSlotId": "e010c56f-ff0b-44b6-bbd9-b50e2ccec2bf"
+    },
+    {
+      "SourceParentOrChildId": "1e5c43bf-da7f-4ff9-939c-7cdc28858fa8",
+      "SourceSlotId": "e66c9218-06dc-4e8d-9f30-9d81f22e39ba",
+      "TargetParentOrChildId": "c6b532a3-af49-4921-9834-fed35229a44b",
+      "TargetSlotId": "e02f9e84-a7bf-45bf-9cb1-0b0c1c396796"
+    },
+    {
+      "SourceParentOrChildId": "c26cbb4e-82c8-40f5-8f1c-b8cff4257071",
+      "SourceSlotId": "8fed46e4-b9df-4d56-b098-9c9a17775139",
+      "TargetParentOrChildId": "c92ce97c-6d3f-4a56-b805-ab05abe12438",
+      "TargetSlotId": "8496877c-6186-4a9f-acb2-ceb90026dc1d"
+    },
+    {
+      "SourceParentOrChildId": "ef29d038-64df-433c-b318-b8e0e4a70703",
+      "SourceSlotId": "5e847363-142d-4da9-a5b3-3a7aa2541bed",
+      "TargetParentOrChildId": "d4071a33-0bc5-4dce-8dee-4db0563e8b09",
+      "TargetSlotId": "944152fb-3786-4474-90ea-c292b5dde801"
+    },
+    {
+      "SourceParentOrChildId": "a17d35a6-4b7b-4839-86db-53e6da087c81",
+      "SourceSlotId": "e6aae72f-8c22-4133-ba0d-c3635751d715",
+      "TargetParentOrChildId": "d5706230-af1a-425a-996e-f4e9d710968e",
+      "TargetSlotId": "4515c98e-05bc-4186-8773-4d2b31a8c323"
+    },
+    {
+      "SourceParentOrChildId": "7e3da07b-e9fb-412a-94b6-3903dd4a4880",
+      "SourceSlotId": "3bb1068a-04ef-4804-83f8-3a3ee6922e2f",
+      "TargetParentOrChildId": "d5ea7059-bcb5-4a8a-8af3-e2a7c1f3c34b",
+      "TargetSlotId": "e010c56f-ff0b-44b6-bbd9-b50e2ccec2bf"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "25ac515f-2f7f-4ebf-9852-fc96bc83d6af",
+      "TargetParentOrChildId": "e859a80f-73e6-404f-8028-93acf66f3235",
+      "TargetSlotId": "75a09454-6cde-458b-9314-05a99b2e5919"
+    },
+    {
+      "SourceParentOrChildId": "68056aa6-31d3-4479-8447-e5ccd9b12e24",
+      "SourceSlotId": "5e847363-142d-4da9-a5b3-3a7aa2541bed",
+      "TargetParentOrChildId": "ef29d038-64df-433c-b318-b8e0e4a70703",
+      "TargetSlotId": "e010c56f-ff0b-44b6-bbd9-b50e2ccec2bf"
+    },
+    {
+      "SourceParentOrChildId": "c26cbb4e-82c8-40f5-8f1c-b8cff4257071",
+      "SourceSlotId": "8fed46e4-b9df-4d56-b098-9c9a17775139",
+      "TargetParentOrChildId": "ef29d038-64df-433c-b318-b8e0e4a70703",
+      "TargetSlotId": "e02f9e84-a7bf-45bf-9cb1-0b0c1c396796"
+    },
+    {
+      "SourceParentOrChildId": "04386033-c5d5-42f7-8403-aa131f3eb1c5",
+      "SourceSlotId": "be16d5d3-4d21-4d5a-9e4c-c7b2779b6bdc",
+      "TargetParentOrChildId": "f092d8ae-80d4-4b7b-ac28-90a848784147",
+      "TargetSlotId": "425ba347-d82a-49ec-b8b4-d0f8f7e3a504"
+    },
+    {
+      "SourceParentOrChildId": "69c19c6c-4285-463e-a1cf-e16b1885f666",
+      "SourceSlotId": "8fed46e4-b9df-4d56-b098-9c9a17775139",
+      "TargetParentOrChildId": "f8ceece9-fc01-49e7-a0d7-8cf7eaa2db67",
+      "TargetSlotId": "4515c98e-05bc-4186-8773-4d2b31a8c323"
+    },
+    {
+      "SourceParentOrChildId": "d5706230-af1a-425a-996e-f4e9d710968e",
+      "SourceSlotId": "8a65b34b-40be-4dbf-812c-d4c663464c7f",
+      "TargetParentOrChildId": "fe5c9a54-b124-4bde-af9a-640c06cbf3d4",
+      "TargetSlotId": "2c0a4eb2-da56-449d-91b8-5ba0870fbeb4"
+    },
+    {
+      "SourceParentOrChildId": "a8b4f066-1e93-42e8-a7fb-0951a422a85b",
+      "SourceSlotId": "87a311ce-238c-472c-b43e-e4ed5268bbc5",
+      "TargetParentOrChildId": "fe5c9a54-b124-4bde-af9a-640c06cbf3d4",
+      "TargetSlotId": "2c0a4eb2-da56-449d-91b8-5ba0870fbeb4"
+    },
+    {
+      "SourceParentOrChildId": "27858375-373c-4374-8ac9-f0f93875380c",
+      "SourceSlotId": "b0cfa6f9-3c3d-4499-b21a-5904d1cb3bd7",
+      "TargetParentOrChildId": "fe5c9a54-b124-4bde-af9a-640c06cbf3d4",
+      "TargetSlotId": "8bbc412b-f574-4a2b-9cbc-bf4f60aebb17"
+    }
+  ]
+}

--- a/Operators/Types/user/community/PlayAtlas_9e243276-1807-49f7-9e78-29b582aafb39.t3
+++ b/Operators/Types/user/community/PlayAtlas_9e243276-1807-49f7-9e78-29b582aafb39.t3
@@ -9,11 +9,11 @@
     },
     {
       "Id": "a47fc959-4ffa-4790-ac1f-5097a72fab3f"/*FrameCountX*/,
-      "DefaultValue": 0
+      "DefaultValue": 1
     },
     {
       "Id": "25ac515f-2f7f-4ebf-9852-fc96bc83d6af"/*FrameCountY*/,
-      "DefaultValue": 0
+      "DefaultValue": 1
     },
     {
       "Id": "65f7f342-fbe8-4fb3-9019-c891fa651d5d"/*FramesToTruncate*/,
@@ -71,23 +71,6 @@
       "Id": "f092d8ae-80d4-4b7b-ac28-90a848784147"/*Int2Components*/,
       "SymbolId": "f86358e0-2573-4acd-9a90-e95108e8a4da",
       "InputValues": [],
-      "Outputs": []
-    },
-    {
-      "Id": "a17d35a6-4b7b-4839-86db-53e6da087c81"/*ClampInt*/,
-      "SymbolId": "5f734c25-9f1a-436c-b56c-7e0a1e07fdda",
-      "InputValues": [
-        {
-          "Id": "e715919d-f3e3-4708-90a6-b55efb379257"/*Min*/,
-          "Type": "System.Int32",
-          "Value": 1
-        },
-        {
-          "Id": "23e55b5d-b469-4d0f-a495-7e87fe65cccf"/*Max*/,
-          "Type": "System.Int32",
-          "Value": 11700000
-        }
-      ],
       "Outputs": []
     },
     {
@@ -207,23 +190,6 @@
       "Id": "561fa13e-cb2b-470b-b50f-e363b9bf0f6c"/*IntValue*/,
       "SymbolId": "cc07b314-4582-4c2c-84b8-bb32f59fc09b",
       "InputValues": [],
-      "Outputs": []
-    },
-    {
-      "Id": "e859a80f-73e6-404f-8028-93acf66f3235"/*ClampInt*/,
-      "SymbolId": "5f734c25-9f1a-436c-b56c-7e0a1e07fdda",
-      "InputValues": [
-        {
-          "Id": "e715919d-f3e3-4708-90a6-b55efb379257"/*Min*/,
-          "Type": "System.Int32",
-          "Value": 1
-        },
-        {
-          "Id": "23e55b5d-b469-4d0f-a495-7e87fe65cccf"/*Max*/,
-          "Type": "System.Int32",
-          "Value": 11700000
-        }
-      ],
       "Outputs": []
     },
     {
@@ -442,65 +408,6 @@
       "Outputs": []
     },
     {
-      "Id": "28ca4d22-2f39-4c4d-ad10-0fde310c14fb"/*IntValue*/,
-      "SymbolId": "cc07b314-4582-4c2c-84b8-bb32f59fc09b",
-      "InputValues": [
-        {
-          "Id": "4515c98e-05bc-4186-8773-4d2b31a8c323"/*Int*/,
-          "Type": "System.Int32",
-          "Value": 2240
-        }
-      ],
-      "Outputs": []
-    },
-    {
-      "Id": "1677c88f-79e5-4c01-b702-4aff1990f1be"/*IntValue*/,
-      "SymbolId": "cc07b314-4582-4c2c-84b8-bb32f59fc09b",
-      "InputValues": [
-        {
-          "Id": "4515c98e-05bc-4186-8773-4d2b31a8c323"/*Int*/,
-          "Type": "System.Int32",
-          "Value": 56
-        }
-      ],
-      "Outputs": []
-    },
-    {
-      "Id": "1f08c22a-aafd-4c61-ac9a-2737b6f72bff"/*IntValue*/,
-      "SymbolId": "cc07b314-4582-4c2c-84b8-bb32f59fc09b",
-      "InputValues": [],
-      "Outputs": []
-    },
-    {
-      "Id": "f758e789-eb94-42b6-b5db-948651f69ae5"/*IterateList*/,
-      "SymbolId": "8b285708-3f20-4957-9eb2-bb40e0d320ee",
-      "InputValues": [],
-      "Outputs": []
-    },
-    {
-      "Id": "67f0ca8e-d1d3-4fbe-9719-a91191d48689"/*ModInt*/,
-      "SymbolId": "cf3268d7-4f3d-47bd-8cb5-0214c75432ec",
-      "InputValues": [],
-      "Outputs": []
-    },
-    {
-      "Id": "62c9f8a8-efad-4f5d-92cd-fe0cd178e195"/*SnapToMultiple*/,
-      "SymbolId": "c3090c65-194a-4f95-9b70-d003f54103f7",
-      "InputValues": [
-        {
-          "Id": "3bf35135-8fb1-46d3-95ea-008eded67060"/*Value*/,
-          "Type": "System.Int32",
-          "Value": 2240
-        },
-        {
-          "Id": "e122bf1d-8455-43f6-867f-4f43f3d6533c"/*Mod*/,
-          "Type": "System.Int32",
-          "Value": 120
-        }
-      ],
-      "Outputs": []
-    },
-    {
       "Id": "a8b4f066-1e93-42e8-a7fb-0951a422a85b"/*SnapToMultiple*/,
       "SymbolId": "c3090c65-194a-4f95-9b70-d003f54103f7",
       "InputValues": [],
@@ -659,8 +566,8 @@
       "TargetSlotId": "e122bf1d-8455-43f6-867f-4f43f3d6533c"
     },
     {
-      "SourceParentOrChildId": "e859a80f-73e6-404f-8028-93acf66f3235",
-      "SourceSlotId": "e6aae72f-8c22-4133-ba0d-c3635751d715",
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "25ac515f-2f7f-4ebf-9852-fc96bc83d6af",
       "TargetParentOrChildId": "561fa13e-cb2b-470b-b50f-e363b9bf0f6c",
       "TargetSlotId": "4515c98e-05bc-4186-8773-4d2b31a8c323"
     },
@@ -809,12 +716,6 @@
       "TargetSlotId": "af866a6c-1ab0-43c0-9e8a-5d25c300e128"
     },
     {
-      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
-      "SourceSlotId": "a47fc959-4ffa-4790-ac1f-5097a72fab3f",
-      "TargetParentOrChildId": "a17d35a6-4b7b-4839-86db-53e6da087c81",
-      "TargetSlotId": "75a09454-6cde-458b-9314-05a99b2e5919"
-    },
-    {
       "SourceParentOrChildId": "f092d8ae-80d4-4b7b-ac28-90a848784147",
       "SourceSlotId": "cd0bd085-dd4a-46a5-bf00-39a199434b30",
       "TargetParentOrChildId": "a8b4f066-1e93-42e8-a7fb-0951a422a85b",
@@ -899,8 +800,8 @@
       "TargetSlotId": "944152fb-3786-4474-90ea-c292b5dde801"
     },
     {
-      "SourceParentOrChildId": "a17d35a6-4b7b-4839-86db-53e6da087c81",
-      "SourceSlotId": "e6aae72f-8c22-4133-ba0d-c3635751d715",
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "a47fc959-4ffa-4790-ac1f-5097a72fab3f",
       "TargetParentOrChildId": "d5706230-af1a-425a-996e-f4e9d710968e",
       "TargetSlotId": "4515c98e-05bc-4186-8773-4d2b31a8c323"
     },
@@ -909,12 +810,6 @@
       "SourceSlotId": "3bb1068a-04ef-4804-83f8-3a3ee6922e2f",
       "TargetParentOrChildId": "d5ea7059-bcb5-4a8a-8af3-e2a7c1f3c34b",
       "TargetSlotId": "e010c56f-ff0b-44b6-bbd9-b50e2ccec2bf"
-    },
-    {
-      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
-      "SourceSlotId": "25ac515f-2f7f-4ebf-9852-fc96bc83d6af",
-      "TargetParentOrChildId": "e859a80f-73e6-404f-8028-93acf66f3235",
-      "TargetSlotId": "75a09454-6cde-458b-9314-05a99b2e5919"
     },
     {
       "SourceParentOrChildId": "68056aa6-31d3-4479-8447-e5ccd9b12e24",

--- a/Operators/Types/user/community/PlayAtlas_9e243276-1807-49f7-9e78-29b582aafb39.t3ui
+++ b/Operators/Types/user/community/PlayAtlas_9e243276-1807-49f7-9e78-29b582aafb39.t3ui
@@ -19,7 +19,9 @@
       },
       "GroupTitle": "Visual Settings",
       "Description": "The number of frames spanning the width of the atlas.",
-      "AddPadding": "True"
+      "AddPadding": "True",
+      "Min": 1,
+      "Clamp": true
     },
     {
       "InputId": "25ac515f-2f7f-4ebf-9852-fc96bc83d6af"/*FrameCountY*/,
@@ -27,7 +29,9 @@
         "X": -431.55664,
         "Y": -103.402405
       },
-      "Description": "The number of frames spanning the height of the atlas."
+      "Description": "The number of frames spanning the height of the atlas.",
+      "Min": 1,
+      "Clamp": true
     },
     {
       "InputId": "65f7f342-fbe8-4fb3-9019-c891fa651d5d"/*FramesToTruncate*/,
@@ -108,13 +112,6 @@
       "Position": {
         "X": 206.82373,
         "Y": -329.7483
-      }
-    },
-    {
-      "ChildId": "a17d35a6-4b7b-4839-86db-53e6da087c81"/*ClampInt*/,
-      "Position": {
-        "X": -27.758392,
-        "Y": 53.472992
       }
     },
     {
@@ -206,13 +203,6 @@
       "Position": {
         "X": -39.186462,
         "Y": 731.2847
-      }
-    },
-    {
-      "ChildId": "e859a80f-73e6-404f-8028-93acf66f3235"/*ClampInt*/,
-      "Position": {
-        "X": -131.83304,
-        "Y": 638.8741
       }
     },
     {
@@ -379,50 +369,8 @@
     {
       "ChildId": "7f3ef40e-4dee-4653-92df-bd4029327144"/*Value*/,
       "Position": {
-        "X": -692.68445,
-        "Y": 258.12955
-      }
-    },
-    {
-      "ChildId": "28ca4d22-2f39-4c4d-ad10-0fde310c14fb"/*IntValue*/,
-      "Position": {
-        "X": -1476.9756,
-        "Y": 380.31586
-      }
-    },
-    {
-      "ChildId": "1677c88f-79e5-4c01-b702-4aff1990f1be"/*IntValue*/,
-      "Position": {
-        "X": -1479.4697,
-        "Y": 301.74713
-      }
-    },
-    {
-      "ChildId": "1f08c22a-aafd-4c61-ac9a-2737b6f72bff"/*IntValue*/,
-      "Position": {
-        "X": -964.6102,
-        "Y": 421.379
-      }
-    },
-    {
-      "ChildId": "f758e789-eb94-42b6-b5db-948651f69ae5"/*IterateList*/,
-      "Position": {
-        "X": -1161.9597,
-        "Y": 598.9934
-      }
-    },
-    {
-      "ChildId": "67f0ca8e-d1d3-4fbe-9719-a91191d48689"/*ModInt*/,
-      "Position": {
-        "X": -1251.0696,
-        "Y": 364.0384
-      }
-    },
-    {
-      "ChildId": "62c9f8a8-efad-4f5d-92cd-fe0cd178e195"/*SnapToMultiple*/,
-      "Position": {
-        "X": -1282.196,
-        "Y": 511.35083
+        "X": -464.9873,
+        "Y": 286.81583
       }
     },
     {

--- a/Operators/Types/user/community/PlayAtlas_9e243276-1807-49f7-9e78-29b582aafb39.t3ui
+++ b/Operators/Types/user/community/PlayAtlas_9e243276-1807-49f7-9e78-29b582aafb39.t3ui
@@ -1,0 +1,580 @@
+{
+  "Id": "9e243276-1807-49f7-9e78-29b582aafb39"/*PlayAtlas*/,
+  "Description": "For animating image atlases. Great for GIFs, spite sheets, tile sets, etc.\n\nBy default, this reacts to Idle Motion.\nIf you don't want this, set the PlaybackRate to 0 and connect a [AnimValue] to a [FloatToInt], then to StartFrame. Alternatively, you could animate StartFrame in the timeline.",
+  "InputUis": [
+    {
+      "InputId": "6bffaa67-be6d-43cc-9890-75d0a1c51d75"/*Texture2d*/,
+      "Relevancy": "Required",
+      "Position": {
+        "X": -431.55664,
+        "Y": -193.4024
+      },
+      "Description": "The input texture atlas. Required."
+    },
+    {
+      "InputId": "a47fc959-4ffa-4790-ac1f-5097a72fab3f"/*FrameCountX*/,
+      "Position": {
+        "X": -431.55664,
+        "Y": -148.4024
+      },
+      "GroupTitle": "Visual Settings",
+      "Description": "The number of frames spanning the width of the atlas.",
+      "AddPadding": "True"
+    },
+    {
+      "InputId": "25ac515f-2f7f-4ebf-9852-fc96bc83d6af"/*FrameCountY*/,
+      "Position": {
+        "X": -431.55664,
+        "Y": -103.402405
+      },
+      "Description": "The number of frames spanning the height of the atlas."
+    },
+    {
+      "InputId": "65f7f342-fbe8-4fb3-9019-c891fa651d5d"/*FramesToTruncate*/,
+      "Position": {
+        "X": -431.55664,
+        "Y": -58.402405
+      },
+      "Description": "An atlas will sometimes have empty frames at the end of the final row. Specify how many here.",
+      "Min": 0,
+      "Scale": 1.0,
+      "Clamp": true
+    },
+    {
+      "InputId": "7304732c-ebfa-41d5-938c-f01ecc228749"/*DisableSnapping*/,
+      "Position": {
+        "X": -431.55664,
+        "Y": -13.402405
+      },
+      "Description": "By default, the FrameCount values will snap to a multiple of the width and height of the atlas, respectively. This option disables that snapping."
+    },
+    {
+      "InputId": "3f7b1f1f-7790-4142-890c-c69a17689b87"/*StartFrame*/,
+      "Position": {
+        "X": -431.55664,
+        "Y": 31.597595
+      },
+      "GroupTitle": "Animation Settings",
+      "Description": "Which frame to show when the time is at 0."
+    },
+    {
+      "InputId": "69c0ee10-8498-4128-b865-7e622b62cd3d"/*PlaybackRate*/,
+      "Position": {
+        "X": -431.55664,
+        "Y": 76.597595
+      },
+      "Description": "The length of time that it takes to go through all of the frames, measured in cycles per bar."
+    },
+    {
+      "InputId": "21212842-58f4-424b-98c2-603423fead1f"/*FineDelay*/,
+      "Position": {
+        "X": -431.55664,
+        "Y": 121.597595
+      },
+      "Description": "Increases or decreases the StartFrame a non-integer amount. Linked to tempo. Requires non-0 PlaybackRate."
+    }
+  ],
+  "SymbolChildUis": [
+    {
+      "ChildId": "13e983a5-3b45-454f-96ba-88903bb653fe"/*Crop*/,
+      "Position": {
+        "X": 2533.4534,
+        "Y": 388.16873
+      }
+    },
+    {
+      "ChildId": "d5706230-af1a-425a-996e-f4e9d710968e"/*IntValue*/,
+      "Position": {
+        "X": 25.125381,
+        "Y": 143.04343
+      }
+    },
+    {
+      "ChildId": "f8ceece9-fc01-49e7-a0d7-8cf7eaa2db67"/*IntValue*/,
+      "Position": {
+        "X": 790.1343,
+        "Y": 1452.4147
+      }
+    },
+    {
+      "ChildId": "04386033-c5d5-42f7-8403-aa131f3eb1c5"/*GetTextureSize*/,
+      "Position": {
+        "X": -24.761597,
+        "Y": -296.10382
+      }
+    },
+    {
+      "ChildId": "f092d8ae-80d4-4b7b-ac28-90a848784147"/*Int2Components*/,
+      "Position": {
+        "X": 206.82373,
+        "Y": -329.7483
+      }
+    },
+    {
+      "ChildId": "a17d35a6-4b7b-4839-86db-53e6da087c81"/*ClampInt*/,
+      "Position": {
+        "X": -27.758392,
+        "Y": 53.472992
+      }
+    },
+    {
+      "ChildId": "824ce6c4-be43-40ae-a65f-e1cf80bf16e1"/*Int2*/,
+      "Position": {
+        "X": 2302.595,
+        "Y": 502.43954
+      }
+    },
+    {
+      "ChildId": "7e3da07b-e9fb-412a-94b6-3903dd4a4880"/*IntDiv*/,
+      "Position": {
+        "X": 819.57446,
+        "Y": 161.45273
+      }
+    },
+    {
+      "ChildId": "700f1d29-bb96-476e-8e7e-666b4faad7ea"/*SubInts*/,
+      "Position": {
+        "X": 1724.4285,
+        "Y": 446.5158
+      }
+    },
+    {
+      "ChildId": "4a14118a-74c5-4f48-ad69-e0215b6b6c6b"/*MultiplyInt*/,
+      "Position": {
+        "X": 1951.2927,
+        "Y": 365.38678
+      }
+    },
+    {
+      "ChildId": "d5ea7059-bcb5-4a8a-8af3-e2a7c1f3c34b"/*MultiplyInt*/,
+      "Position": {
+        "X": 1825.2178,
+        "Y": 241.53079
+      }
+    },
+    {
+      "ChildId": "6b5d582a-7766-4dfb-9bd6-5ef9d8dd1aac"/*AddInts*/,
+      "Position": {
+        "X": 1517.03,
+        "Y": 483.4265
+      }
+    },
+    {
+      "ChildId": "c6adaa8e-714b-409b-9cb6-dd80c46ce278"/*MultiplyInt*/,
+      "Position": {
+        "X": 1985.071,
+        "Y": 604.8128
+      }
+    },
+    {
+      "ChildId": "5f70e665-df3c-4a35-a713-5afc39d3d488"/*ModInt*/,
+      "Position": {
+        "X": 1371.9825,
+        "Y": 643.6753
+      }
+    },
+    {
+      "ChildId": "82b7c2fe-56d3-4194-8813-7532777c257a"/*MaxInt*/,
+      "Position": {
+        "X": -665.5041,
+        "Y": 1319.5815
+      }
+    },
+    {
+      "ChildId": "a1fe5622-1a68-4601-857c-0b3b7c186a1e"/*IntValue*/,
+      "Position": {
+        "X": -745.0218,
+        "Y": 1261.5083
+      }
+    },
+    {
+      "ChildId": "fe5c9a54-b124-4bde-af9a-640c06cbf3d4"/*PickInt*/,
+      "Position": {
+        "X": 538.38354,
+        "Y": 186.32388
+      }
+    },
+    {
+      "ChildId": "27858375-373c-4374-8ac9-f0f93875380c"/*BoolToInt*/,
+      "Position": {
+        "X": -49.021675,
+        "Y": 215.91092
+      }
+    },
+    {
+      "ChildId": "561fa13e-cb2b-470b-b50f-e363b9bf0f6c"/*IntValue*/,
+      "Position": {
+        "X": -39.186462,
+        "Y": 731.2847
+      }
+    },
+    {
+      "ChildId": "e859a80f-73e6-404f-8028-93acf66f3235"/*ClampInt*/,
+      "Position": {
+        "X": -131.83304,
+        "Y": 638.8741
+      }
+    },
+    {
+      "ChildId": "4afe5445-6d8f-4165-b97b-7415f29c6ac8"/*IntDiv*/,
+      "Position": {
+        "X": 710.06146,
+        "Y": 748.66656
+      }
+    },
+    {
+      "ChildId": "580e3af2-7af4-40f0-a0a1-15051f9f208c"/*PickInt*/,
+      "Position": {
+        "X": 428.87073,
+        "Y": 773.53766
+      }
+    },
+    {
+      "ChildId": "42a89bc0-e86e-4683-b9c2-92a793f183b1"/*BoolToInt*/,
+      "Position": {
+        "X": -172.83124,
+        "Y": 799.9963
+      }
+    },
+    {
+      "ChildId": "1e5c43bf-da7f-4ff9-939c-7cdc28858fa8"/*SubInts*/,
+      "Position": {
+        "X": 1741.2513,
+        "Y": 1110.6885
+      }
+    },
+    {
+      "ChildId": "c6b532a3-af49-4921-9834-fed35229a44b"/*MultiplyInt*/,
+      "Position": {
+        "X": 1968.1156,
+        "Y": 1029.5586
+      }
+    },
+    {
+      "ChildId": "68056aa6-31d3-4479-8447-e5ccd9b12e24"/*MultiplyInt*/,
+      "Position": {
+        "X": 1842.0406,
+        "Y": 905.7027
+      }
+    },
+    {
+      "ChildId": "c92ce97c-6d3f-4a56-b805-ab05abe12438"/*AddInts*/,
+      "Position": {
+        "X": 1533.8529,
+        "Y": 1147.5991
+      }
+    },
+    {
+      "ChildId": "ef29d038-64df-433c-b318-b8e0e4a70703"/*MultiplyInt*/,
+      "Position": {
+        "X": 2001.8939,
+        "Y": 1268.9854
+      }
+    },
+    {
+      "ChildId": "c26cbb4e-82c8-40f5-8f1c-b8cff4257071"/*ModInt*/,
+      "Position": {
+        "X": 1346.0464,
+        "Y": 1292.4985
+      }
+    },
+    {
+      "ChildId": "2c2ab357-a955-4a11-a60f-d0228ad3601d"/*Int2*/,
+      "Position": {
+        "X": 2355.5542,
+        "Y": 1092.8279
+      }
+    },
+    {
+      "ChildId": "28126558-fff8-4114-bacb-ea556909c6cd"/*IntDiv*/,
+      "Position": {
+        "X": 1078.0026,
+        "Y": 1249.6451
+      }
+    },
+    {
+      "ChildId": "74833d7b-dbaf-48b2-b246-1037f4239a4b"/*MultiplyInt*/,
+      "Position": {
+        "X": -574.17456,
+        "Y": 1108.8267
+      }
+    },
+    {
+      "ChildId": "99f16266-04a0-4fe9-a088-74451f6ce130"/*SubInts*/,
+      "Position": {
+        "X": -400.765,
+        "Y": 1148.7363
+      }
+    },
+    {
+      "ChildId": "69c19c6c-4285-463e-a1cf-e16b1885f666"/*ModInt*/,
+      "Position": {
+        "X": 632.8211,
+        "Y": 1501.0205
+      }
+    },
+    {
+      "ChildId": "b9073aa9-6186-4ff4-8ea1-f5903c910726"/*AnimValue*/,
+      "Position": {
+        "X": -28.205048,
+        "Y": 1100.9982
+      }
+    },
+    {
+      "ChildId": "c34fc007-5c8d-4f95-9d08-66bc0f07fed2"/*IntToFloat*/,
+      "Position": {
+        "X": -208.3504,
+        "Y": 1109.1896
+      }
+    },
+    {
+      "ChildId": "39d005dc-6169-4468-bcd8-87a0e6053aaa"/*Floor*/,
+      "Position": {
+        "X": 122.08798,
+        "Y": 1215.7823
+      }
+    },
+    {
+      "ChildId": "9dc00663-f34f-4996-a2ec-96c974277ed1"/*FloatToInt*/,
+      "Position": {
+        "X": 328.3892,
+        "Y": 1236.292
+      }
+    },
+    {
+      "ChildId": "618853ef-3f49-4dd9-aafa-a9dabace62ef"/*SubInts*/,
+      "Position": {
+        "X": 2157.2827,
+        "Y": 610.03687
+      }
+    },
+    {
+      "ChildId": "1d7dde02-cfdc-42b2-953e-ad4cb3ec8cff"/*SubInts*/,
+      "Position": {
+        "X": 2123.154,
+        "Y": 390.29742
+      }
+    },
+    {
+      "ChildId": "2e138248-d920-4813-9db7-3d44126e0313"/*SubInts*/,
+      "Position": {
+        "X": 2148.7373,
+        "Y": 961.00665
+      }
+    },
+    {
+      "ChildId": "d4071a33-0bc5-4dce-8dee-4db0563e8b09"/*SubInts*/,
+      "Position": {
+        "X": 2177.9746,
+        "Y": 1185.7659
+      }
+    },
+    {
+      "ChildId": "03686acc-a185-4e57-97cd-075736dccc86"/*AddInts*/,
+      "Position": {
+        "X": 438.03357,
+        "Y": 1425.6674
+      }
+    },
+    {
+      "ChildId": "7f3ef40e-4dee-4653-92df-bd4029327144"/*Value*/,
+      "Position": {
+        "X": -692.68445,
+        "Y": 258.12955
+      }
+    },
+    {
+      "ChildId": "28ca4d22-2f39-4c4d-ad10-0fde310c14fb"/*IntValue*/,
+      "Position": {
+        "X": -1476.9756,
+        "Y": 380.31586
+      }
+    },
+    {
+      "ChildId": "1677c88f-79e5-4c01-b702-4aff1990f1be"/*IntValue*/,
+      "Position": {
+        "X": -1479.4697,
+        "Y": 301.74713
+      }
+    },
+    {
+      "ChildId": "1f08c22a-aafd-4c61-ac9a-2737b6f72bff"/*IntValue*/,
+      "Position": {
+        "X": -964.6102,
+        "Y": 421.379
+      }
+    },
+    {
+      "ChildId": "f758e789-eb94-42b6-b5db-948651f69ae5"/*IterateList*/,
+      "Position": {
+        "X": -1161.9597,
+        "Y": 598.9934
+      }
+    },
+    {
+      "ChildId": "67f0ca8e-d1d3-4fbe-9719-a91191d48689"/*ModInt*/,
+      "Position": {
+        "X": -1251.0696,
+        "Y": 364.0384
+      }
+    },
+    {
+      "ChildId": "62c9f8a8-efad-4f5d-92cd-fe0cd178e195"/*SnapToMultiple*/,
+      "Position": {
+        "X": -1282.196,
+        "Y": 511.35083
+      }
+    },
+    {
+      "ChildId": "a8b4f066-1e93-42e8-a7fb-0951a422a85b"/*SnapToMultiple*/,
+      "Position": {
+        "X": 397.62436,
+        "Y": 54.60092
+      }
+    },
+    {
+      "ChildId": "532e59d9-f633-46b8-9ca9-c9d4710a76ec"/*SnapToMultiple*/,
+      "Position": {
+        "X": 279.0811,
+        "Y": 671.2021
+      }
+    }
+  ],
+  "OutputUis": [
+    {
+      "OutputId": "372da297-6bb0-49fc-a92f-41bfcc5f9f1a"/*output*/,
+      "Position": {
+        "X": 2763.9717,
+        "Y": 386.58987
+      }
+    }
+  ],
+  "Annotations": [
+    {
+      "Id": "f71ec894-31e5-45ef-b0a3-5f4582f63d60",
+      "Title": "offset rn",
+      "Color": {
+        "X": 0.6,
+        "Y": 0.6,
+        "Z": 0.6,
+        "W": 1.0
+      },
+      "Position": {
+        "X": 753.9782,
+        "Y": 1415.1879
+      },
+      "Size": {
+        "X": 209.08987,
+        "Y": 88.1029
+      }
+    },
+    {
+      "Id": "b4e6b0ad-dd73-4a69-a281-d4dcdf63060f",
+      "Title": "Xstepsize",
+      "Color": {
+        "X": 0.6,
+        "Y": 0.6,
+        "Z": 0.6,
+        "W": 1.0
+      },
+      "Position": {
+        "X": 798.74695,
+        "Y": 119.27557
+      },
+      "Size": {
+        "X": 172.02046,
+        "Y": 119.87665
+      }
+    },
+    {
+      "Id": "1daaf43b-8f71-44eb-b747-092524794cb7",
+      "Title": "X crop amt calculation",
+      "Color": {
+        "X": 0.6,
+        "Y": 0.6,
+        "Z": 0.6,
+        "W": 1.0
+      },
+      "Position": {
+        "X": 1333.1884,
+        "Y": 159.68726
+      },
+      "Size": {
+        "X": 1112.5743,
+        "Y": 594.80524
+      }
+    },
+    {
+      "Id": "ba2ce098-3695-4995-873d-3f475181b01e",
+      "Title": "Xstepsize calculation\n",
+      "Color": {
+        "X": 0.6,
+        "Y": 0.6,
+        "Z": 0.6,
+        "W": 1.0
+      },
+      "Position": {
+        "X": -141.55167,
+        "Y": -132.38626
+      },
+      "Size": {
+        "X": 1161.1133,
+        "Y": 457.42007
+      }
+    },
+    {
+      "Id": "b5a942f2-5593-49df-aee2-e2f0322421e2",
+      "Title": "Ystepsize",
+      "Color": {
+        "X": 0.6,
+        "Y": 0.6,
+        "Z": 0.6,
+        "W": 1.0
+      },
+      "Position": {
+        "X": 671.85547,
+        "Y": 717.4778
+      },
+      "Size": {
+        "X": 172.02046,
+        "Y": 119.87665
+      }
+    },
+    {
+      "Id": "0d9f91a5-4c35-41d9-9a81-ea905eec0fa4",
+      "Title": "Ystepsize calculation\n",
+      "Color": {
+        "X": 0.6,
+        "Y": 0.6,
+        "Z": 0.6,
+        "W": 1.0
+      },
+      "Position": {
+        "X": -245.62631,
+        "Y": 453.01465
+      },
+      "Size": {
+        "X": 1121.9514,
+        "Y": 466.1676
+      }
+    },
+    {
+      "Id": "cf0f0fae-af98-4a29-9e3e-cd460b130022",
+      "Title": "Y crop amt calculaton",
+      "Color": {
+        "X": 0.6,
+        "Y": 0.6,
+        "Z": 0.6,
+        "W": 1.0
+      },
+      "Position": {
+        "X": 1269.2959,
+        "Y": 827.0665
+      },
+      "Size": {
+        "X": 1256.4142,
+        "Y": 568.7994
+      }
+    }
+  ]
+}

--- a/Operators/Types/user/community/SnapToMultiple.cs
+++ b/Operators/Types/user/community/SnapToMultiple.cs
@@ -1,0 +1,38 @@
+using T3.Core.Operator;
+using T3.Core.Operator.Attributes;
+using T3.Core.Operator.Slots;
+
+namespace T3.Operators.Types.Id_c3090c65_194a_4f95_9b70_d003f54103f7 
+{
+    public class SnapToMultiple : Instance<SnapToMultiple>
+    {
+        [Output(Guid = "87a311ce-238c-472c-b43e-e4ed5268bbc5")]
+        public readonly Slot<int> Result = new();
+
+        public SnapToMultiple()
+        {
+            Result.UpdateAction = Update;
+        }
+
+        private void Update(EvaluationContext context)
+        {
+            var v = Value.GetValue(context);
+            var mod = Mod.GetValue(context);
+            if (mod == 0){
+                return;
+			}
+            for(int goodvalue=mod;goodvalue>0;goodvalue--){
+				if(v%goodvalue == 0){
+					Result.Value = goodvalue;
+					return;
+				}
+			}
+        }
+        
+        [Input(Guid = "3bf35135-8fb1-46d3-95ea-008eded67060")]
+        public readonly InputSlot<int> Value = new();
+
+        [Input(Guid = "e122bf1d-8455-43f6-867f-4f43f3d6533c")]
+        public readonly InputSlot<int> Mod = new();
+    }
+}

--- a/Operators/Types/user/community/SnapToMultiple.cs
+++ b/Operators/Types/user/community/SnapToMultiple.cs
@@ -18,15 +18,17 @@ namespace T3.Operators.Types.Id_c3090c65_194a_4f95_9b70_d003f54103f7
         {
             var v = Value.GetValue(context);
             var mod = Mod.GetValue(context);
-            if (mod == 0){
-                return;
-			}
-            for(int goodvalue=mod;goodvalue>0;goodvalue--){
-				if(v%goodvalue == 0){
-					Result.Value = goodvalue;
+
+            for(int nextLowestMod=mod;nextLowestMod>0;nextLowestMod--)
+			{
+				if(v%nextLowestMod == 0)
+				{
+					Result.Value = nextLowestMod;
 					return;
 				}
+				
 			}
+			
         }
         
         [Input(Guid = "3bf35135-8fb1-46d3-95ea-008eded67060")]

--- a/Operators/Types/user/community/SnapToMultiple_c3090c65-194a-4f95-9b70-d003f54103f7.t3
+++ b/Operators/Types/user/community/SnapToMultiple_c3090c65-194a-4f95-9b70-d003f54103f7.t3
@@ -1,0 +1,17 @@
+{
+  "Name": "SnapToMultiple",
+  "Id": "c3090c65-194a-4f95-9b70-d003f54103f7",
+  "Namespace": "user.community",
+  "Inputs": [
+    {
+      "Id": "3bf35135-8fb1-46d3-95ea-008eded67060"/*Value*/,
+      "DefaultValue": 0
+    },
+    {
+      "Id": "e122bf1d-8455-43f6-867f-4f43f3d6533c"/*Mod*/,
+      "DefaultValue": 1
+    }
+  ],
+  "Children": [],
+  "Connections": []
+}

--- a/Operators/Types/user/community/SnapToMultiple_c3090c65-194a-4f95-9b70-d003f54103f7.t3ui
+++ b/Operators/Types/user/community/SnapToMultiple_c3090c65-194a-4f95-9b70-d003f54103f7.t3ui
@@ -1,0 +1,30 @@
+{
+  "Id": "c3090c65-194a-4f95-9b70-d003f54103f7"/*SnapToMultiple*/,
+  "Description": "Similar to [ModInt], but instead of returning the remainder after the division by Mod, it returns the next lowest value of Mod that would result in a remainder of 0.",
+  "InputUis": [
+    {
+      "InputId": "3bf35135-8fb1-46d3-95ea-008eded67060"/*Value*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 0.0
+      }
+    },
+    {
+      "InputId": "e122bf1d-8455-43f6-867f-4f43f3d6533c"/*Mod*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 45.0
+      }
+    }
+  ],
+  "SymbolChildUis": [],
+  "OutputUis": [
+    {
+      "OutputId": "87a311ce-238c-472c-b43e-e4ed5268bbc5"/*Result*/,
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0
+      }
+    }
+  ]
+}


### PR DESCRIPTION
An operator for turning Atlases into animations, for use with GIFs, sprite sheets, etc. For a better user experience, I've also included SnapToMultiple, which will return the lowest divisor of a number that has a modulus of 0. 
![playatlas](https://github.com/tooll3/t3/assets/14063531/dfdbd696-717d-4bd8-a749-550911b00f26)