### PR TITLE
Feature/extrude curve compatibility

### DIFF
--- a/Operators/Types/examples/lib/3d/mesh/generate/ExtrudeCurvesExample.cs
+++ b/Operators/Types/examples/lib/3d/mesh/generate/ExtrudeCurvesExample.cs
@@ -10,6 +10,9 @@ namespace T3.Operators.Types.Id_a469ca9f_a7f9_46b8_b34c_0a1c109e1222
         [Output(Guid = "7661ebdf-0d10-437a-8b3e-71fac37cbd1a")]
         public readonly Slot<Texture2D> ColorBuffer = new Slot<Texture2D>();
 
+        [Input(Guid = "7c55d6c6-d712-4464-8dd8-2b7fac96e270")]
+        public readonly InputSlot<bool> FixHoles = new InputSlot<bool>();
+
 
     }
 }

--- a/Operators/Types/examples/lib/3d/mesh/generate/ExtrudeCurvesExample_a469ca9f-a7f9-46b8-b34c-0a1c109e1222.t3
+++ b/Operators/Types/examples/lib/3d/mesh/generate/ExtrudeCurvesExample_a469ca9f-a7f9-46b8-b34c-0a1c109e1222.t3
@@ -2,7 +2,12 @@
   "Name": "ExtrudeCurvesExample",
   "Id": "a469ca9f-a7f9-46b8-b34c-0a1c109e1222",
   "Namespace": "examples.lib.3d.mesh.generate",
-  "Inputs": [],
+  "Inputs": [
+    {
+      "Id": "7c55d6c6-d712-4464-8dd8-2b7fac96e270"/*FixHoles*/,
+      "DefaultValue": true
+    }
+  ],
   "Children": [
     {
       "Id": "4583340c-5329-4335-ac58-006d735efecb"/*RadialPoints*/,
@@ -52,7 +57,13 @@
     {
       "Id": "edfaece3-0993-4692-8e83-4872cc26b190"/*ExtrudeCurves*/,
       "SymbolId": "816336a8-e214-4d2c-b8f9-05b1aa3ff2e2",
-      "InputValues": [],
+      "InputValues": [
+        {
+          "Id": "8104d7e7-0cea-4009-851d-1b0a23802ad8"/*FixHoles*/,
+          "Type": "System.Boolean",
+          "Value": false
+        }
+      ],
       "Outputs": []
     },
     {
@@ -154,7 +165,13 @@
     {
       "Id": "093227ab-7a81-458c-96f1-50ec06ddaa96"/*ExtrudeCurves*/,
       "SymbolId": "816336a8-e214-4d2c-b8f9-05b1aa3ff2e2",
-      "InputValues": [],
+      "InputValues": [
+        {
+          "Id": "8104d7e7-0cea-4009-851d-1b0a23802ad8"/*FixHoles*/,
+          "Type": "System.Boolean",
+          "Value": true
+        }
+      ],
       "Outputs": []
     },
     {
@@ -427,6 +444,11 @@
           "Id": "7a2eff05-ab49-42ab-816c-86937f0ebbaf"/*UseExtend*/,
           "Type": "System.Boolean",
           "Value": false
+        },
+        {
+          "Id": "8104d7e7-0cea-4009-851d-1b0a23802ad8"/*FixHoles*/,
+          "Type": "System.Boolean",
+          "Value": false
         }
       ],
       "Outputs": []
@@ -523,73 +545,62 @@
       "Outputs": []
     },
     {
-      "Id": "b3536c72-6d52-44cb-afa4-e57a1d234ee1"/*RenderTarget*/,
-      "SymbolId": "f9fe78c5-43a6-48ae-8e8c-6cdbbc330dd1",
-      "InputValues": [],
-      "Outputs": []
-    },
-    {
-      "Id": "5af277db-64f4-4516-ba2f-60e0251cb2eb"/*RenderTarget*/,
-      "SymbolId": "f9fe78c5-43a6-48ae-8e8c-6cdbbc330dd1",
-      "InputValues": [],
-      "Outputs": []
-    },
-    {
       "Id": "1b0e749a-908c-4eee-81f6-948872cefa64"/*OrbitCamera*/,
-      "SymbolId": "6415ed0e-3692-45e2-8e70-fe0cf4d29ebc",
-      "InputValues": [],
-      "Outputs": []
-    },
-    {
-      "Id": "b4d4e373-9bb3-4dd7-97b5-6c1e59ad9310"/*OrbitCamera*/,
       "SymbolId": "6415ed0e-3692-45e2-8e70-fe0cf4d29ebc",
       "InputValues": [
         {
-          "Id": "acf14901-3373-4b0c-8567-03ea0051a21f"/*CameraTargetPosition*/,
-          "Type": "System.Numerics.Vector3",
-          "Value": {
-            "X": 0.0,
-            "Y": 0.14,
-            "Z": 0.0
-          }
-        },
-        {
           "Id": "dd92fb0a-4b3e-4492-bf59-437d914a1ad3"/*DistanceToTarget*/,
           "Type": "System.Single",
-          "Value": 1.28
+          "Value": 5.43
         }
       ],
       "Outputs": []
     },
     {
-      "Id": "9f381017-be08-4865-8252-883abbf279a0"/*OrbitCamera*/,
-      "SymbolId": "6415ed0e-3692-45e2-8e70-fe0cf4d29ebc",
+      "Id": "00690cf0-4b53-477b-a67c-a175cf225a54"/*SpreadLayout*/,
+      "SymbolId": "e07550cf-033a-443d-b6f3-73eb71c72d9d",
       "InputValues": [
         {
-          "Id": "acf14901-3373-4b0c-8567-03ea0051a21f"/*CameraTargetPosition*/,
+          "Id": "a46dba34-0a69-4a9e-8e76-5dc01054fbb4"/*Spread*/,
           "Type": "System.Numerics.Vector3",
           "Value": {
             "X": 0.0,
-            "Y": 0.84,
-            "Z": 0.0
+            "Y": 0.0,
+            "Z": 3.68
           }
         },
         {
-          "Id": "dd92fb0a-4b3e-4492-bf59-437d914a1ad3"/*DistanceToTarget*/,
-          "Type": "System.Single",
-          "Value": 3.81
-        },
-        {
-          "Id": "df65e717-e2fd-4e4f-9e41-d6bcd3fe67f1"/*SpinRate*/,
-          "Type": "System.Single",
-          "Value": 0.16
-        },
-        {
-          "Id": "8b75047f-03b7-4619-8869-2906e66731d1"/*OrbitAngleAndWobble*/,
-          "Type": "System.Numerics.Vector2",
+          "Id": "2d59d002-838e-4150-ae8f-ff97bb19bd78"/*Translation*/,
+          "Type": "System.Numerics.Vector3",
           "Value": {
-            "X": 37.5,
-            "Y": 11.0
+            "X": 0.0,
+            "Y": 0.0,
+            "Z": 0.23
+          }
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "a27d91e0-443c-410e-9349-8784b779d80c"/*Camera*/,
+      "SymbolId": "746d886c-5ab6-44b1-bb15-f3ce2fadf7e6",
+      "InputValues": [
+        {
+          "Id": "313596cc-3854-436b-89da-5fd40164ce76"/*Position*/,
+          "Type": "System.Numerics.Vector3",
+          "Value": {
+            "X": 7.9218283,
+            "Y": 2.7891736,
+            "Z": 0.9271101
+          }
+        },
+        {
+          "Id": "a7acb25c-d60c-43a6-b1df-2cd5c6e183f3"/*Target*/,
+          "Type": "System.Numerics.Vector3",
+          "Value": {
+            "X": 0.0,
+            "Y": 0.0,
+            "Z": 0.0
           }
         }
       ],
@@ -604,6 +615,24 @@
       "TargetSlotId": "7661ebdf-0d10-437a-8b3e-71fac37cbd1a"
     },
     {
+      "SourceParentOrChildId": "e0f93b7d-e0cb-47bf-be46-bd7c5016c234",
+      "SourceSlotId": "e81c99ce-fcee-4e7c-a1c7-0aa3b352b7e1",
+      "TargetParentOrChildId": "00690cf0-4b53-477b-a67c-a175cf225a54",
+      "TargetSlotId": "2f112e29-beb3-4b78-a9e6-5d4ed55b49c7"
+    },
+    {
+      "SourceParentOrChildId": "5ebd17ca-037d-4a6b-83cc-0ba1ea338a7c",
+      "SourceSlotId": "9300b07e-977d-47b0-908e-c4b1e5e53a64",
+      "TargetParentOrChildId": "00690cf0-4b53-477b-a67c-a175cf225a54",
+      "TargetSlotId": "2f112e29-beb3-4b78-a9e6-5d4ed55b49c7"
+    },
+    {
+      "SourceParentOrChildId": "30ad898c-0460-48ef-a8a2-7c54bc3bd0ea",
+      "SourceSlotId": "e81c99ce-fcee-4e7c-a1c7-0aa3b352b7e1",
+      "TargetParentOrChildId": "00690cf0-4b53-477b-a67c-a175cf225a54",
+      "TargetSlotId": "2f112e29-beb3-4b78-a9e6-5d4ed55b49c7"
+    },
+    {
       "SourceParentOrChildId": "aa7df5f4-145b-447b-b3aa-a1b6f5f196bb",
       "SourceSlotId": "ba17981e-ef9f-46f1-a653-6d50affa8838",
       "TargetParentOrChildId": "06257687-4e25-4a78-ab9f-02b07d3e9b54",
@@ -616,8 +645,8 @@
       "TargetSlotId": "54fc4cd7-dfc3-4690-9fd1-2b555f7656d4"
     },
     {
-      "SourceParentOrChildId": "c9283ba0-508f-4fa3-92ce-fec0afaa3754",
-      "SourceSlotId": "68514ced-4368-459a-80e9-463a808bff0b",
+      "SourceParentOrChildId": "b522af85-d4d6-4d1c-a5e8-4eae02345698",
+      "SourceSlotId": "bea6aa18-e751-4ce7-b7d7-b7a026c8e019",
       "TargetParentOrChildId": "093227ab-7a81-458c-96f1-50ec06ddaa96",
       "TargetSlotId": "4d31be7a-3011-4fdf-9c63-425387b9bbfc"
     },
@@ -626,6 +655,12 @@
       "SourceSlotId": "d7605a96-adc6-4a2b-9ba4-33adef3b7f4c",
       "TargetParentOrChildId": "093227ab-7a81-458c-96f1-50ec06ddaa96",
       "TargetSlotId": "5e2ada8d-10fa-419d-a377-0b504437fd72"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "7c55d6c6-d712-4464-8dd8-2b7fac96e270",
+      "TargetParentOrChildId": "093227ab-7a81-458c-96f1-50ec06ddaa96",
+      "TargetSlotId": "8104d7e7-0cea-4009-851d-1b0a23802ad8"
     },
     {
       "SourceParentOrChildId": "241ddeb6-90b3-494e-84c6-0ca13b019b59",
@@ -640,8 +675,8 @@
       "TargetSlotId": "cb157c8e-98f1-46e9-b197-d17dea896e30"
     },
     {
-      "SourceParentOrChildId": "5ebd17ca-037d-4a6b-83cc-0ba1ea338a7c",
-      "SourceSlotId": "9300b07e-977d-47b0-908e-c4b1e5e53a64",
+      "SourceParentOrChildId": "00690cf0-4b53-477b-a67c-a175cf225a54",
+      "SourceSlotId": "60c25429-be91-4552-b1fe-b08479793abe",
       "TargetParentOrChildId": "1b0e749a-908c-4eee-81f6-948872cefa64",
       "TargetSlotId": "33752356-8348-4938-8f73-6257e6bb1c1f"
     },
@@ -674,12 +709,6 @@
       "SourceSlotId": "79ba19e0-13c3-40c7-8e0a-f190b03e95b0",
       "TargetParentOrChildId": "58499561-6980-49e1-950d-2b3685a6a6ce",
       "TargetSlotId": "97429e1f-3f30-4789-89a6-8e930e356ee6"
-    },
-    {
-      "SourceParentOrChildId": "9f381017-be08-4865-8252-883abbf279a0",
-      "SourceSlotId": "14a63b62-5fbb-4f82-8cf3-d0faf279eff8",
-      "TargetParentOrChildId": "5af277db-64f4-4516-ba2f-60e0251cb2eb",
-      "TargetSlotId": "4da253b7-4953-439a-b03f-1d515a78bddf"
     },
     {
       "SourceParentOrChildId": "5f98af3c-29b1-43be-88ba-371a5f8e4f11",
@@ -730,28 +759,22 @@
       "TargetSlotId": "5e2ada8d-10fa-419d-a377-0b504437fd72"
     },
     {
-      "SourceParentOrChildId": "e0f93b7d-e0cb-47bf-be46-bd7c5016c234",
-      "SourceSlotId": "e81c99ce-fcee-4e7c-a1c7-0aa3b352b7e1",
-      "TargetParentOrChildId": "9f381017-be08-4865-8252-883abbf279a0",
-      "TargetSlotId": "33752356-8348-4938-8f73-6257e6bb1c1f"
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "7c55d6c6-d712-4464-8dd8-2b7fac96e270",
+      "TargetParentOrChildId": "9ee99d7b-cbe5-4db7-ab7b-6043317db940",
+      "TargetSlotId": "8104d7e7-0cea-4009-851d-1b0a23802ad8"
+    },
+    {
+      "SourceParentOrChildId": "00690cf0-4b53-477b-a67c-a175cf225a54",
+      "SourceSlotId": "60c25429-be91-4552-b1fe-b08479793abe",
+      "TargetParentOrChildId": "a27d91e0-443c-410e-9349-8784b779d80c",
+      "TargetSlotId": "047b8fae-468c-48a7-8f3a-5fac8dd5b3c6"
     },
     {
       "SourceParentOrChildId": "23521927-63a4-4393-a4f4-1b5e9c721def",
       "SourceSlotId": "bb886ff1-31a9-47aa-a39a-fa60ebb6c2d6",
       "TargetParentOrChildId": "aa7df5f4-145b-447b-b3aa-a1b6f5f196bb",
       "TargetSlotId": "565ff364-c3d9-4c60-a9a0-79fdd36d3477"
-    },
-    {
-      "SourceParentOrChildId": "b4d4e373-9bb3-4dd7-97b5-6c1e59ad9310",
-      "SourceSlotId": "14a63b62-5fbb-4f82-8cf3-d0faf279eff8",
-      "TargetParentOrChildId": "b3536c72-6d52-44cb-afa4-e57a1d234ee1",
-      "TargetSlotId": "4da253b7-4953-439a-b03f-1d515a78bddf"
-    },
-    {
-      "SourceParentOrChildId": "30ad898c-0460-48ef-a8a2-7c54bc3bd0ea",
-      "SourceSlotId": "e81c99ce-fcee-4e7c-a1c7-0aa3b352b7e1",
-      "TargetParentOrChildId": "b4d4e373-9bb3-4dd7-97b5-6c1e59ad9310",
-      "TargetSlotId": "33752356-8348-4938-8f73-6257e6bb1c1f"
     },
     {
       "SourceParentOrChildId": "c9283ba0-508f-4fa3-92ce-fec0afaa3754",
@@ -806,6 +829,12 @@
       "SourceSlotId": "d7605a96-adc6-4a2b-9ba4-33adef3b7f4c",
       "TargetParentOrChildId": "edfaece3-0993-4692-8e83-4872cc26b190",
       "TargetSlotId": "5e2ada8d-10fa-419d-a377-0b504437fd72"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "7c55d6c6-d712-4464-8dd8-2b7fac96e270",
+      "TargetParentOrChildId": "edfaece3-0993-4692-8e83-4872cc26b190",
+      "TargetSlotId": "8104d7e7-0cea-4009-851d-1b0a23802ad8"
     },
     {
       "SourceParentOrChildId": "edfaece3-0993-4692-8e83-4872cc26b190",

--- a/Operators/Types/examples/lib/3d/mesh/generate/ExtrudeCurvesExample_a469ca9f-a7f9-46b8-b34c-0a1c109e1222.t3ui
+++ b/Operators/Types/examples/lib/3d/mesh/generate/ExtrudeCurvesExample_a469ca9f-a7f9-46b8-b34c-0a1c109e1222.t3ui
@@ -1,7 +1,15 @@
 {
   "Id": "a469ca9f-a7f9-46b8-b34c-0a1c109e1222"/*ExtrudeCurvesExample*/,
-  "Description": "Three example setups made by newemka for the [ExtrudeCurves] operator.",
-  "InputUis": [],
+  "Description": "If the mesh surface has holes, activate FixHoles. Three example setups made by newemka for the [ExtrudeCurves] operator.",
+  "InputUis": [
+    {
+      "InputId": "7c55d6c6-d712-4464-8dd8-2b7fac96e270"/*FixHoles*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 0.0
+      }
+    }
+  ],
   "SymbolChildUis": [
     {
       "ChildId": "4583340c-5329-4335-ac58-006d735efecb"/*RadialPoints*/,
@@ -34,8 +42,8 @@
     {
       "ChildId": "8f372609-be2c-4967-a63b-7759bea7c767"/*RenderTarget*/,
       "Position": {
-        "X": 1795.2789,
-        "Y": 470.54443
+        "X": 1881.9102,
+        "Y": 798.5057
       }
     },
     {
@@ -61,6 +69,7 @@
     },
     {
       "ChildId": "093227ab-7a81-458c-96f1-50ec06ddaa96"/*ExtrudeCurves*/,
+      "Comment": "If the generated mesh has holes on its surface, activate FixHoles",
       "Position": {
         "X": 518.8099,
         "Y": 216.13086
@@ -70,22 +79,22 @@
       "ChildId": "ea1fdfa1-f00b-4700-ba9a-353b4540bf97"/*RadialPoints*/,
       "Comment": "It's important to adjust the OrientationAngle in order to have the Normals (Z axis / blue line) looking outward the circle. Use [VisualizePoints] to check the points orientation.",
       "Position": {
-        "X": 130.50662,
-        "Y": 287.7412
+        "X": 134.55615,
+        "Y": 416.31384
       }
     },
     {
       "ChildId": "b522af85-d4d6-4d1c-a5e8-4eae02345698"/*AddNoise*/,
       "Position": {
-        "X": 320.2232,
-        "Y": 0.0
+        "X": 324.94763,
+        "Y": 216.48119
       }
     },
     {
       "ChildId": "241ddeb6-90b3-494e-84c6-0ca13b019b59"/*Time*/,
       "Position": {
-        "X": 19.565498,
-        "Y": 83.77197
+        "X": -215.55356,
+        "Y": 75.37488
       }
     },
     {
@@ -225,8 +234,8 @@
     {
       "ChildId": "0aba651d-2123-4126-9c8d-3cc801e775b2"/*RandomizePoints*/,
       "Position": {
-        "X": 353.1888,
-        "Y": 73.33496
+        "X": 324.94763,
+        "Y": 285.4812
       }
     },
     {
@@ -238,38 +247,24 @@
       }
     },
     {
-      "ChildId": "b3536c72-6d52-44cb-afa4-e57a1d234ee1"/*RenderTarget*/,
-      "Position": {
-        "X": 1444.2552,
-        "Y": 910.7446
-      }
-    },
-    {
-      "ChildId": "5af277db-64f4-4516-ba2f-60e0251cb2eb"/*RenderTarget*/,
-      "Position": {
-        "X": 1612.1979,
-        "Y": 1332.689
-      }
-    },
-    {
       "ChildId": "1b0e749a-908c-4eee-81f6-948872cefa64"/*OrbitCamera*/,
       "Position": {
-        "X": 1409.8793,
-        "Y": 266.5201
+        "X": 1731.9102,
+        "Y": 798.5057
       }
     },
     {
-      "ChildId": "b4d4e373-9bb3-4dd7-97b5-6c1e59ad9310"/*OrbitCamera*/,
+      "ChildId": "00690cf0-4b53-477b-a67c-a175cf225a54"/*SpreadLayout*/,
       "Position": {
-        "X": 1200.8708,
-        "Y": 835.8551
+        "X": 1436.76,
+        "Y": 786.08704
       }
     },
     {
-      "ChildId": "9f381017-be08-4865-8252-883abbf279a0"/*OrbitCamera*/,
+      "ChildId": "a27d91e0-443c-410e-9349-8784b779d80c"/*Camera*/,
       "Position": {
-        "X": 1414.608,
-        "Y": 1240.6316
+        "X": 1731.9102,
+        "Y": 742.5057
       }
     }
   ],
@@ -333,8 +328,8 @@
         "Y": 184.74121
       },
       "Size": {
-        "X": 605.7703,
-        "Y": 182.03404
+        "X": 602.73315,
+        "Y": 340.97824
       }
     }
   ]

--- a/Operators/Types/lib/3d/mesh/generate/ExtrudeCurves.cs
+++ b/Operators/Types/lib/3d/mesh/generate/ExtrudeCurves.cs
@@ -25,6 +25,9 @@ namespace T3.Operators.Types.Id_816336a8_e214_4d2c_b8f9_05b1aa3ff2e2
         [Input(Guid = "7a2eff05-ab49-42ab-816c-86937f0ebbaf")]
         public readonly InputSlot<bool> UseExtend = new InputSlot<bool>();
 
+        [Input(Guid = "8104d7e7-0cea-4009-851d-1b0a23802ad8")]
+        public readonly InputSlot<bool> FixHoles = new InputSlot<bool>();
+
 
         private enum SampleModes
         {

--- a/Operators/Types/lib/3d/mesh/generate/ExtrudeCurves_816336a8-e214-4d2c-b8f9-05b1aa3ff2e2.t3
+++ b/Operators/Types/lib/3d/mesh/generate/ExtrudeCurves_816336a8-e214-4d2c-b8f9-05b1aa3ff2e2.t3
@@ -22,6 +22,10 @@
     {
       "Id": "7a2eff05-ab49-42ab-816c-86937f0ebbaf"/*UseExtend*/,
       "DefaultValue": false
+    },
+    {
+      "Id": "8104d7e7-0cea-4009-851d-1b0a23802ad8"/*FixHoles*/,
+      "DefaultValue": false
     }
   ],
   "Children": [
@@ -244,6 +248,44 @@
       "SymbolId": "9db2fcbf-54b9-4222-878b-80d1a0dc6edf",
       "InputValues": [],
       "Outputs": []
+    },
+    {
+      "Id": "e6cc1859-fea7-48a8-96a9-3dbba9d71f27"/*Source*/,
+      "SymbolId": "5880cbc3-a541-4484-a06a-0e6f77cdbe8e",
+      "Name": "Source",
+      "InputValues": [
+        {
+          "Id": "ceeae47b-d792-471d-a825-49e22749b7b9"/*InputString*/,
+          "Type": "System.String",
+          "Value": "Resources\\lib\\points\\onmesh\\ExtrudeCurves.hlsl"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "05d1072c-ee6e-40e6-80a4-106d6a0dbda6"/*Source*/,
+      "SymbolId": "5880cbc3-a541-4484-a06a-0e6f77cdbe8e",
+      "Name": "Source",
+      "InputValues": [
+        {
+          "Id": "ceeae47b-d792-471d-a825-49e22749b7b9"/*InputString*/,
+          "Type": "System.String",
+          "Value": "Resources\\lib\\points\\onmesh\\ExtrudeCurves_alternative.hlsl"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "ea94207b-a29a-4cf1-99e6-12b1bfc61791"/*PickString*/,
+      "SymbolId": "a9784e5e-7696-49a0-bb77-2302587ede59",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "bd7770dc-9639-476d-9a36-7173ad9bc9f4"/*BoolToInt*/,
+      "SymbolId": "cd43942a-887e-4e34-bc54-0c2e5e8bc2af",
+      "InputValues": [],
+      "Outputs": []
     }
   ],
   "Connections": [
@@ -252,6 +294,12 @@
       "SourceSlotId": "d71893dd-6ca2-4ab7-9e04-0bd7285eccfb",
       "TargetParentOrChildId": "00000000-0000-0000-0000-000000000000",
       "TargetSlotId": "79ba19e0-13c3-40c7-8e0a-f190b03e95b0"
+    },
+    {
+      "SourceParentOrChildId": "ea94207b-a29a-4cf1-99e6-12b1bfc61791",
+      "SourceSlotId": "74104eb6-dfc2-4ad2-9600-91c5a33855d4",
+      "TargetParentOrChildId": "1641928b-9226-453d-803c-36e1340513ad",
+      "TargetSlotId": "afb69c81-5063-4cb9-9d42-841b994b5ec0"
     },
     {
       "SourceParentOrChildId": "5fb2df02-6c03-40ba-a512-bb010060e9cc",
@@ -380,6 +428,12 @@
       "TargetSlotId": "f79ccc37-05fd-4f81-97d6-6c1cafca180c"
     },
     {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "8104d7e7-0cea-4009-851d-1b0a23802ad8",
+      "TargetParentOrChildId": "bd7770dc-9639-476d-9a36-7173ad9bc9f4",
+      "TargetSlotId": "c644165f-3901-4dbf-8091-05f958e668e5"
+    },
+    {
       "SourceParentOrChildId": "fa666161-c5ea-49c9-b42a-704a49190a5a",
       "SourceSlotId": "c997268d-6709-49de-980e-64d7a47504f7",
       "TargetParentOrChildId": "d886b15d-f366-43fd-8a72-380eaed4d3fe",
@@ -438,6 +492,24 @@
       "SourceSlotId": "7a2eff05-ab49-42ab-816c-86937f0ebbaf",
       "TargetParentOrChildId": "e752e32f-84bc-4e55-9caa-a165cecb3447",
       "TargetSlotId": "253b9ae4-fac5-4641-bf0c-d8614606a840"
+    },
+    {
+      "SourceParentOrChildId": "e6cc1859-fea7-48a8-96a9-3dbba9d71f27",
+      "SourceSlotId": "dd9d8718-addc-49b1-bd33-aac22b366f94",
+      "TargetParentOrChildId": "ea94207b-a29a-4cf1-99e6-12b1bfc61791",
+      "TargetSlotId": "202ce6d5-ee5a-41c7-bd04-4c1490f3ea9c"
+    },
+    {
+      "SourceParentOrChildId": "05d1072c-ee6e-40e6-80a4-106d6a0dbda6",
+      "SourceSlotId": "dd9d8718-addc-49b1-bd33-aac22b366f94",
+      "TargetParentOrChildId": "ea94207b-a29a-4cf1-99e6-12b1bfc61791",
+      "TargetSlotId": "202ce6d5-ee5a-41c7-bd04-4c1490f3ea9c"
+    },
+    {
+      "SourceParentOrChildId": "bd7770dc-9639-476d-9a36-7173ad9bc9f4",
+      "SourceSlotId": "b0cfa6f9-3c3d-4499-b21a-5904d1cb3bd7",
+      "TargetParentOrChildId": "ea94207b-a29a-4cf1-99e6-12b1bfc61791",
+      "TargetSlotId": "20e76577-92ee-443d-9630-ebc41e38bb85"
     },
     {
       "SourceParentOrChildId": "3c00f419-fe83-4279-8193-4e0afb8f7fe2",

--- a/Operators/Types/lib/3d/mesh/generate/ExtrudeCurves_816336a8-e214-4d2c-b8f9-05b1aa3ff2e2.t3ui
+++ b/Operators/Types/lib/3d/mesh/generate/ExtrudeCurves_816336a8-e214-4d2c-b8f9-05b1aa3ff2e2.t3ui
@@ -38,6 +38,16 @@
         "X": -1423.521,
         "Y": 1169.9822
       }
+    },
+    {
+      "InputId": "8104d7e7-0cea-4009-851d-1b0a23802ad8"/*FixHoles*/,
+      "Position": {
+        "X": -1423.521,
+        "Y": 1214.9822
+      },
+      "GroupTitle": "Alternative Method",
+      "Description": "Activate if the mesh doesn't look right (holes). We noticed a compatibility issue with some GPUs.",
+      "AddPadding": "True"
     }
   ],
   "SymbolChildUis": [
@@ -207,6 +217,44 @@
       "Position": {
         "X": -937.3934,
         "Y": 1231.455
+      }
+    },
+    {
+      "ChildId": "e6cc1859-fea7-48a8-96a9-3dbba9d71f27"/*Source*/,
+      "Style": "Resizable",
+      "Size": {
+        "X": 171.57288,
+        "Y": 17.878124
+      },
+      "Position": {
+        "X": -583.1848,
+        "Y": 415.87204
+      }
+    },
+    {
+      "ChildId": "05d1072c-ee6e-40e6-80a4-106d6a0dbda6"/*Source*/,
+      "Style": "Resizable",
+      "Size": {
+        "X": 171.57288,
+        "Y": 17.878124
+      },
+      "Position": {
+        "X": -585.38196,
+        "Y": 475.74628
+      }
+    },
+    {
+      "ChildId": "ea94207b-a29a-4cf1-99e6-12b1bfc61791"/*PickString*/,
+      "Position": {
+        "X": -322.7276,
+        "Y": 455.8299
+      }
+    },
+    {
+      "ChildId": "bd7770dc-9639-476d-9a36-7173ad9bc9f4"/*BoolToInt*/,
+      "Position": {
+        "X": -1074.1956,
+        "Y": 1343.9025
       }
     }
   ],

--- a/Resources/lib/points/onmesh/ExtrudeCurves_alternative.hlsl
+++ b/Resources/lib/points/onmesh/ExtrudeCurves_alternative.hlsl
@@ -1,0 +1,98 @@
+#include "lib/shared/hash-functions.hlsl"
+#include "lib/shared/noise-functions.hlsl"
+#include "lib/shared/point.hlsl"
+#include "lib/shared/quat-functions.hlsl"
+#include "lib/shared/pbr.hlsl"
+
+cbuffer Params : register(b0)
+{
+    float UseWAsWidth;
+    float UseStretch;
+    float Width;
+}
+
+StructuredBuffer<Point> RailPoints : t0;
+StructuredBuffer<Point> ShapePoints : t1;
+
+RWStructuredBuffer<PbrVertex> Vertices : u0;
+RWStructuredBuffer<int4> TriangleIndices : u1;
+
+
+
+[numthreads(64,1,1)]
+void main(uint3 i : SV_DispatchThreadID)
+{
+
+    uint triangleCount, stride;
+    TriangleIndices.GetDimensions(triangleCount, stride);
+
+    uint vertexCount;
+    Vertices.GetDimensions(vertexCount, stride);
+
+    if(i.x >= vertexCount) {
+        return;
+    }
+
+
+    uint rows;
+    ShapePoints.GetDimensions(rows, stride);
+
+    uint columns;
+    RailPoints.GetDimensions(columns, stride);
+
+    uint vertexIndex = i.x;
+    uint rowIndex = vertexIndex % rows;
+    uint columnIndex = vertexIndex / rows;
+
+    PbrVertex v;
+    Point railPoint = RailPoints[columnIndex];
+    Point shapePoint = ShapePoints[rowIndex];
+
+    float3 scaleFactor = (UseStretch ? railPoint.Stretch : 1)
+     *  (UseWAsWidth ? railPoint.W : 1) * Width;;
+
+    float4 rotation = normalize(qMul( railPoint.Rotation ,shapePoint.Rotation ));
+    float3 position = qRotateVec3(shapePoint.Position * scaleFactor, railPoint.Rotation) + railPoint.Position;
+
+    //float3 normal =
+
+    v.Position =  position;
+    v.Normal = qRotateVec3(float3(0,0,1), rotation);
+    v.Tangent = qRotateVec3(float3(0,1,0), rotation);
+    v.Bitangent = qRotateVec3(float3(1,0,0), rotation);
+    v.TexCoord = float2((float)columnIndex/(columns-1),(float)rowIndex/(rows-1));
+    v.Selected = 1;
+    v.__padding =0;
+
+    Vertices[vertexIndex] = v;
+    if(isnan(railPoint.W ) || isnan(shapePoint.W) )
+        Vertices[vertexIndex].Position = float3(0,0,0);
+    
+
+    // Write face indices
+    if (columnIndex < columns - 1 && rowIndex < rows - 1) 
+    {
+        int faceIndex =  2 * (rowIndex + columnIndex * (rows-1));
+
+        if(
+            isnan(railPoint.W) 
+            || isnan(RailPoints[columnIndex+1].W) 
+            || isnan(shapePoint.W) 
+            || isnan(ShapePoints[rowIndex+1].W) 
+         ) 
+        {
+            if (columnIndex < columns - 1 && rowIndex < rows - 1) 
+            {
+                TriangleIndices[faceIndex + 0] = int4(0, 0, 0, 0);
+                TriangleIndices[faceIndex + 1] = int4(0, 0, 0, 0);
+                //TriangleIndices[faceIndex + 1] = int4(0, 0, 0, 0); //commented duplicate line
+            }
+             if(isnan(railPoint.W ) || isnan(shapePoint.W) )
+                 Vertices[vertexIndex].Position = float3(0,0,0);
+            return;
+        }        
+        TriangleIndices[faceIndex + 0] = int4(vertexIndex + 1, vertexIndex + rows, vertexIndex, 0);
+        TriangleIndices[faceIndex + 1] = int4(vertexIndex + 1, vertexIndex + rows + 1, vertexIndex + rows, 0);
+    }
+}
+


### PR DESCRIPTION
[ac05086](https://github.com/tooll3/t3/commit/ac05086e01dde920bb49497673e60ace57a3e0be) : Fixed [ExtrudeCurves] for some users but broke it for others. 
I've added a boolean parameter allowing to switch between both versions of the HLSL file.
![ExtrudeCurves01](https://github.com/tooll3/t3/assets/3755089/304b7a6f-48c9-4181-b14a-e604ebb1c03f)
![ExtrudeCurves02](https://github.com/tooll3/t3/assets/3755089/683b1e9e-79e7-4e3c-a3bc-4a291b6c0109)
