### PR TITLE
Feature/new midi outputs

### DIFF
--- a/Operators/Types/examples/lib/io/midi/MidiNoteOutputExample.cs
+++ b/Operators/Types/examples/lib/io/midi/MidiNoteOutputExample.cs
@@ -1,0 +1,16 @@
+using SharpDX.Direct3D11;
+using T3.Core.Operator;
+using T3.Core.Operator.Attributes;
+using T3.Core.Operator.Slots;
+
+namespace T3.Operators.Types.Id_cb2cdd1d_811a_4a30_a5bc_289f36c31028
+{
+    public class MidiNoteOutputExample : Instance<MidiNoteOutputExample>
+    {
+        [Output(Guid = "3a972c37-fcf8-4c5f-b932-97ac9f6d5d99")]
+        public readonly Slot<Texture2D> ColorBuffer = new();
+
+
+    }
+}
+

--- a/Operators/Types/examples/lib/io/midi/MidiNoteOutputExample_cb2cdd1d-811a-4a30-a5bc-289f36c31028.t3
+++ b/Operators/Types/examples/lib/io/midi/MidiNoteOutputExample_cb2cdd1d-811a-4a30-a5bc-289f36c31028.t3
@@ -1,0 +1,401 @@
+{
+  "Name": "MidiNoteOutputExample",
+  "Id": "cb2cdd1d-811a-4a30-a5bc-289f36c31028",
+  "Namespace": "examples.lib.io.midi",
+  "Inputs": [],
+  "Children": [
+    {
+      "Id": "1bf38671-c3f7-4693-8af3-8e745d6b0f4c"/*Execute*/,
+      "SymbolId": "936e4324-bea2-463a-b196-6064a2d8a6b2",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "077c96f1-a1d8-404b-b8d3-00652ba90fbe"/*RenderTarget*/,
+      "SymbolId": "f9fe78c5-43a6-48ae-8e8c-6cdbbc330dd1",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "a8a4da22-2b04-4b69-9884-7f0242c11b96"/*MidiNoteOutput*/,
+      "SymbolId": "642cec4f-d4e0-4d0a-8dc3-6ca8339b5f89",
+      "InputValues": [
+        {
+          "Id": "97a4f0d3-e691-4c2c-b731-7e4afc77eed2"/*Device*/,
+          "Type": "System.String",
+          "Value": "loopMIDI Port 1"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "9b4ee829-04a7-40e4-86e0-bc5e530a7646"/*MidiControlOutput*/,
+      "SymbolId": "a59c583b-dbc2-495c-a9b1-e64fc1e5d532",
+      "InputValues": [
+        {
+          "Id": "b8612a7d-cb19-4203-b5d0-a44ca71f5477"/*SendMode*/,
+          "Type": "System.Int32",
+          "Value": 1
+        },
+        {
+          "Id": "aff6a747-7c3d-4cef-a5b7-daf9a60fcba0"/*Device*/,
+          "Type": "System.String",
+          "Value": "loopMIDI Port 1"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "75d47ec9-5a71-4b01-a2fe-7c986ed68128"/*MidiPitchbendOutput*/,
+      "SymbolId": "01d33d21-d75e-4c22-bfe6-088e1ee4a5e8",
+      "InputValues": [
+        {
+          "Id": "93868179-7d95-46c3-bd2c-8d6039afee69"/*Device*/,
+          "Type": "System.String",
+          "Value": "loopMIDI Port 1"
+        },
+        {
+          "Id": "068a8ef1-9aa4-4e67-9700-5138358fa0b9"/*UsePitchFloat*/,
+          "Type": "System.Boolean",
+          "Value": true
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "1862207a-335f-46c3-912a-f1d1058af8f8"/*PerlinNoise*/,
+      "SymbolId": "436e93a8-03c0-4366-8d9a-2245e5bcaa6c",
+      "InputValues": [
+        {
+          "Id": "e704cf6c-963e-4701-ba3d-127b880676fa"/*Amplitude*/,
+          "Type": "System.Single",
+          "Value": 1.0
+        },
+        {
+          "Id": "b112705e-3ec3-4904-b978-bc784d9b2f94"/*RangeMin*/,
+          "Type": "System.Single",
+          "Value": 45.0
+        },
+        {
+          "Id": "557ae817-ec36-4866-8fed-64490e9255be"/*RangeMax*/,
+          "Type": "System.Single",
+          "Value": 100.0
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "ea70c0bf-8366-4398-8f3a-b7e001820631"/*FloatToInt*/,
+      "SymbolId": "06b4728e-852c-491a-a89d-647f7e0b5415",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "bf88e6f2-94b3-402c-bc28-58a0cb96c1df"/*AnimValue*/,
+      "SymbolId": "ea7b8491-2f8e-4add-b0b1-fd068ccfed0d",
+      "InputValues": [
+        {
+          "Id": "4cf5d20b-7335-4584-b246-c260ac5cdf4f"/*Shape*/,
+          "Type": "System.Int32",
+          "Value": 4
+        },
+        {
+          "Id": "48005727-0158-4795-ad70-8410c27fd01d"/*Rate*/,
+          "Type": "System.Single",
+          "Value": 2.0
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "15c61174-64e8-48b0-b0ff-11dc153b0242"/*PerlinNoise*/,
+      "SymbolId": "436e93a8-03c0-4366-8d9a-2245e5bcaa6c",
+      "InputValues": [
+        {
+          "Id": "e704cf6c-963e-4701-ba3d-127b880676fa"/*Amplitude*/,
+          "Type": "System.Single",
+          "Value": 1.0
+        },
+        {
+          "Id": "b112705e-3ec3-4904-b978-bc784d9b2f94"/*RangeMin*/,
+          "Type": "System.Single",
+          "Value": 45.0
+        },
+        {
+          "Id": "557ae817-ec36-4866-8fed-64490e9255be"/*RangeMax*/,
+          "Type": "System.Single",
+          "Value": 100.0
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "afd3e48a-5b41-4d0a-89ea-2ea940dfbd05"/*FloatToInt*/,
+      "SymbolId": "06b4728e-852c-491a-a89d-647f7e0b5415",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "a2a6dffe-cf23-42ac-a671-ccd70c18ca43"/*Time*/,
+      "SymbolId": "9cb4d49e-135b-400b-a035-2b02c5ea6a72",
+      "InputValues": [
+        {
+          "Id": "2d9c040d-5244-40ac-8090-d8d57323487b"/*SpeedFactor*/,
+          "Type": "System.Single",
+          "Value": 0.5
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "55e4e59c-d79e-4fba-a7fb-8f8b80b626c8"/*PerlinNoise*/,
+      "SymbolId": "436e93a8-03c0-4366-8d9a-2245e5bcaa6c",
+      "InputValues": [
+        {
+          "Id": "557ae817-ec36-4866-8fed-64490e9255be"/*RangeMax*/,
+          "Type": "System.Single",
+          "Value": 2.0
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "7cd70612-036e-4bb7-97f7-169c8c2fbadb"/*Accumulator*/,
+      "SymbolId": "90b2c6d2-e9a6-4910-b42d-94202f07be27",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "d2efdd50-5e2c-439c-965d-a2fc9d4193de"/*PerlinNoise*/,
+      "SymbolId": "436e93a8-03c0-4366-8d9a-2245e5bcaa6c",
+      "InputValues": [
+        {
+          "Id": "e704cf6c-963e-4701-ba3d-127b880676fa"/*Amplitude*/,
+          "Type": "System.Single",
+          "Value": 1.0
+        },
+        {
+          "Id": "b112705e-3ec3-4904-b978-bc784d9b2f94"/*RangeMin*/,
+          "Type": "System.Single",
+          "Value": 45.0
+        },
+        {
+          "Id": "557ae817-ec36-4866-8fed-64490e9255be"/*RangeMax*/,
+          "Type": "System.Single",
+          "Value": 100.0
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "8407f8c0-df09-45e0-bb3d-83f9210403ee"/*FloatToInt*/,
+      "SymbolId": "06b4728e-852c-491a-a89d-647f7e0b5415",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "d05399ae-0e00-4178-a1d3-95341b85f89e"/*AnimValue*/,
+      "SymbolId": "ea7b8491-2f8e-4add-b0b1-fd068ccfed0d",
+      "InputValues": [
+        {
+          "Id": "4cf5d20b-7335-4584-b246-c260ac5cdf4f"/*Shape*/,
+          "Type": "System.Int32",
+          "Value": 11
+        },
+        {
+          "Id": "48005727-0158-4795-ad70-8410c27fd01d"/*Rate*/,
+          "Type": "System.Single",
+          "Value": 1.0
+        },
+        {
+          "Id": "8327e7ec-4370-4a3e-bd69-db3f4aa4b1d7"/*Ratio*/,
+          "Type": "System.Single",
+          "Value": 0.01
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "959c0b83-e17e-4ed0-bf46-d6c425b1f9ff"/*Spring*/,
+      "SymbolId": "0b337922-aeca-473a-bfe9-4ab6ff804b11",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "1756c6f3-c263-459d-92ce-e1a9cc3c1faf"/*PickFloat*/,
+      "SymbolId": "63e6e642-827b-4518-ac64-9ab0a8d4391e",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "80f073fe-da3b-40c3-8fd2-a0132b95f9e6"/*Value*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "f54a2058-0b89-459e-b285-58a1bb99c7ad"/*BoolToInt*/,
+      "SymbolId": "cd43942a-887e-4e34-bc54-0c2e5e8bc2af",
+      "InputValues": [],
+      "Outputs": []
+    }
+  ],
+  "Connections": [
+    {
+      "SourceParentOrChildId": "077c96f1-a1d8-404b-b8d3-00652ba90fbe",
+      "SourceSlotId": "7a4c4feb-be2f-463e-96c6-cd9a6bad77a2",
+      "TargetParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "TargetSlotId": "3a972c37-fcf8-4c5f-b932-97ac9f6d5d99"
+    },
+    {
+      "SourceParentOrChildId": "1bf38671-c3f7-4693-8af3-8e745d6b0f4c",
+      "SourceSlotId": "e81c99ce-fcee-4e7c-a1c7-0aa3b352b7e1",
+      "TargetParentOrChildId": "077c96f1-a1d8-404b-b8d3-00652ba90fbe",
+      "TargetSlotId": "4da253b7-4953-439a-b03f-1d515a78bddf"
+    },
+    {
+      "SourceParentOrChildId": "a2a6dffe-cf23-42ac-a671-ccd70c18ca43",
+      "SourceSlotId": "a606b326-f3af-470b-b6e5-3175f7a54e31",
+      "TargetParentOrChildId": "15c61174-64e8-48b0-b0ff-11dc153b0242",
+      "TargetSlotId": "eabbaf77-5f74-4303-9453-6fa44facc5db"
+    },
+    {
+      "SourceParentOrChildId": "f54a2058-0b89-459e-b285-58a1bb99c7ad",
+      "SourceSlotId": "b0cfa6f9-3c3d-4499-b21a-5904d1cb3bd7",
+      "TargetParentOrChildId": "1756c6f3-c263-459d-92ce-e1a9cc3c1faf",
+      "TargetSlotId": "465b4fc3-899c-4b97-9892-f237fa6613e8"
+    },
+    {
+      "SourceParentOrChildId": "80f073fe-da3b-40c3-8fd2-a0132b95f9e6",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "1756c6f3-c263-459d-92ce-e1a9cc3c1faf",
+      "TargetSlotId": "d7ef7f1a-a6bd-4f94-a29a-bb19e2854001"
+    },
+    {
+      "SourceParentOrChildId": "d05399ae-0e00-4178-a1d3-95341b85f89e",
+      "SourceSlotId": "ae4addf0-08cf-4b25-9515-4fef9359d183",
+      "TargetParentOrChildId": "1756c6f3-c263-459d-92ce-e1a9cc3c1faf",
+      "TargetSlotId": "d7ef7f1a-a6bd-4f94-a29a-bb19e2854001"
+    },
+    {
+      "SourceParentOrChildId": "a2a6dffe-cf23-42ac-a671-ccd70c18ca43",
+      "SourceSlotId": "a606b326-f3af-470b-b6e5-3175f7a54e31",
+      "TargetParentOrChildId": "1862207a-335f-46c3-912a-f1d1058af8f8",
+      "TargetSlotId": "eabbaf77-5f74-4303-9453-6fa44facc5db"
+    },
+    {
+      "SourceParentOrChildId": "a8a4da22-2b04-4b69-9884-7f0242c11b96",
+      "SourceSlotId": "2cb961e5-c188-4190-b02b-753784cafca3",
+      "TargetParentOrChildId": "1bf38671-c3f7-4693-8af3-8e745d6b0f4c",
+      "TargetSlotId": "5d73ebe6-9aa0-471a-ae6b-3f5bfd5a0f9c"
+    },
+    {
+      "SourceParentOrChildId": "9b4ee829-04a7-40e4-86e0-bc5e530a7646",
+      "SourceSlotId": "2bde4fd3-e74e-49c1-9fe5-867060067566",
+      "TargetParentOrChildId": "1bf38671-c3f7-4693-8af3-8e745d6b0f4c",
+      "TargetSlotId": "5d73ebe6-9aa0-471a-ae6b-3f5bfd5a0f9c"
+    },
+    {
+      "SourceParentOrChildId": "75d47ec9-5a71-4b01-a2fe-7c986ed68128",
+      "SourceSlotId": "402d1d43-5eab-46f0-88c9-2c978e4223e8",
+      "TargetParentOrChildId": "1bf38671-c3f7-4693-8af3-8e745d6b0f4c",
+      "TargetSlotId": "5d73ebe6-9aa0-471a-ae6b-3f5bfd5a0f9c"
+    },
+    {
+      "SourceParentOrChildId": "a2a6dffe-cf23-42ac-a671-ccd70c18ca43",
+      "SourceSlotId": "a606b326-f3af-470b-b6e5-3175f7a54e31",
+      "TargetParentOrChildId": "55e4e59c-d79e-4fba-a7fb-8f8b80b626c8",
+      "TargetSlotId": "eabbaf77-5f74-4303-9453-6fa44facc5db"
+    },
+    {
+      "SourceParentOrChildId": "959c0b83-e17e-4ed0-bf46-d6c425b1f9ff",
+      "SourceSlotId": "e989b1ae-c7c0-4209-89c7-3aa589695d85",
+      "TargetParentOrChildId": "75d47ec9-5a71-4b01-a2fe-7c986ed68128",
+      "TargetSlotId": "e92b7f08-18c6-402b-a4dc-bf553f881593"
+    },
+    {
+      "SourceParentOrChildId": "55e4e59c-d79e-4fba-a7fb-8f8b80b626c8",
+      "SourceSlotId": "4a62f8ae-cb15-4e63-ad8d-749bdf24982c",
+      "TargetParentOrChildId": "7cd70612-036e-4bb7-97f7-169c8c2fbadb",
+      "TargetSlotId": "052f9cd1-4b3e-483f-b628-c356f58ff87e"
+    },
+    {
+      "SourceParentOrChildId": "d2efdd50-5e2c-439c-965d-a2fc9d4193de",
+      "SourceSlotId": "4a62f8ae-cb15-4e63-ad8d-749bdf24982c",
+      "TargetParentOrChildId": "8407f8c0-df09-45e0-bb3d-83f9210403ee",
+      "TargetSlotId": "af866a6c-1ab0-43c0-9e8a-5d25c300e128"
+    },
+    {
+      "SourceParentOrChildId": "1756c6f3-c263-459d-92ce-e1a9cc3c1faf",
+      "SourceSlotId": "72add436-84aa-4332-b061-be8d50981c77",
+      "TargetParentOrChildId": "959c0b83-e17e-4ed0-bf46-d6c425b1f9ff",
+      "TargetSlotId": "782eb1a4-ee2a-4326-a7dc-7a40c5fb9b7c"
+    },
+    {
+      "SourceParentOrChildId": "bf88e6f2-94b3-402c-bc28-58a0cb96c1df",
+      "SourceSlotId": "5538411f-e6e5-4dff-9cf4-a6410be49a8c",
+      "TargetParentOrChildId": "9b4ee829-04a7-40e4-86e0-bc5e530a7646",
+      "TargetSlotId": "5188cc2f-723c-497c-bfb8-1b00a3006327"
+    },
+    {
+      "SourceParentOrChildId": "8407f8c0-df09-45e0-bb3d-83f9210403ee",
+      "SourceSlotId": "1eb7c5c4-0982-43f4-b14d-524571e3cdda",
+      "TargetParentOrChildId": "9b4ee829-04a7-40e4-86e0-bc5e530a7646",
+      "TargetSlotId": "57096500-4ee4-4221-a7e7-1d2a065d01c8"
+    },
+    {
+      "SourceParentOrChildId": "afd3e48a-5b41-4d0a-89ea-2ea940dfbd05",
+      "SourceSlotId": "1eb7c5c4-0982-43f4-b14d-524571e3cdda",
+      "TargetParentOrChildId": "a8a4da22-2b04-4b69-9884-7f0242c11b96",
+      "TargetSlotId": "90221c60-c7ac-4470-affb-e4fb22712ee5"
+    },
+    {
+      "SourceParentOrChildId": "ea70c0bf-8366-4398-8f3a-b7e001820631",
+      "SourceSlotId": "1eb7c5c4-0982-43f4-b14d-524571e3cdda",
+      "TargetParentOrChildId": "a8a4da22-2b04-4b69-9884-7f0242c11b96",
+      "TargetSlotId": "a33619fa-bb33-4649-a714-285c5cce15dc"
+    },
+    {
+      "SourceParentOrChildId": "bf88e6f2-94b3-402c-bc28-58a0cb96c1df",
+      "SourceSlotId": "5538411f-e6e5-4dff-9cf4-a6410be49a8c",
+      "TargetParentOrChildId": "a8a4da22-2b04-4b69-9884-7f0242c11b96",
+      "TargetSlotId": "e1c1c77a-a6af-4565-b345-f788bf268b2b"
+    },
+    {
+      "SourceParentOrChildId": "15c61174-64e8-48b0-b0ff-11dc153b0242",
+      "SourceSlotId": "4a62f8ae-cb15-4e63-ad8d-749bdf24982c",
+      "TargetParentOrChildId": "afd3e48a-5b41-4d0a-89ea-2ea940dfbd05",
+      "TargetSlotId": "af866a6c-1ab0-43c0-9e8a-5d25c300e128"
+    },
+    {
+      "SourceParentOrChildId": "7cd70612-036e-4bb7-97f7-169c8c2fbadb",
+      "SourceSlotId": "a999f93c-e51a-4325-bae2-bfab830b868d",
+      "TargetParentOrChildId": "bf88e6f2-94b3-402c-bc28-58a0cb96c1df",
+      "TargetSlotId": "7b4992ba-30f7-42e5-b04b-ae4ec0be810e"
+    },
+    {
+      "SourceParentOrChildId": "7cd70612-036e-4bb7-97f7-169c8c2fbadb",
+      "SourceSlotId": "a999f93c-e51a-4325-bae2-bfab830b868d",
+      "TargetParentOrChildId": "d05399ae-0e00-4178-a1d3-95341b85f89e",
+      "TargetSlotId": "7b4992ba-30f7-42e5-b04b-ae4ec0be810e"
+    },
+    {
+      "SourceParentOrChildId": "a2a6dffe-cf23-42ac-a671-ccd70c18ca43",
+      "SourceSlotId": "a606b326-f3af-470b-b6e5-3175f7a54e31",
+      "TargetParentOrChildId": "d2efdd50-5e2c-439c-965d-a2fc9d4193de",
+      "TargetSlotId": "eabbaf77-5f74-4303-9453-6fa44facc5db"
+    },
+    {
+      "SourceParentOrChildId": "1862207a-335f-46c3-912a-f1d1058af8f8",
+      "SourceSlotId": "4a62f8ae-cb15-4e63-ad8d-749bdf24982c",
+      "TargetParentOrChildId": "ea70c0bf-8366-4398-8f3a-b7e001820631",
+      "TargetSlotId": "af866a6c-1ab0-43c0-9e8a-5d25c300e128"
+    },
+    {
+      "SourceParentOrChildId": "d05399ae-0e00-4178-a1d3-95341b85f89e",
+      "SourceSlotId": "5538411f-e6e5-4dff-9cf4-a6410be49a8c",
+      "TargetParentOrChildId": "f54a2058-0b89-459e-b285-58a1bb99c7ad",
+      "TargetSlotId": "c644165f-3901-4dbf-8091-05f958e668e5"
+    }
+  ]
+}

--- a/Operators/Types/examples/lib/io/midi/MidiNoteOutputExample_cb2cdd1d-811a-4a30-a5bc-289f36c31028.t3ui
+++ b/Operators/Types/examples/lib/io/midi/MidiNoteOutputExample_cb2cdd1d-811a-4a30-a5bc-289f36c31028.t3ui
@@ -1,0 +1,194 @@
+{
+  "Id": "cb2cdd1d-811a-4a30-a5bc-289f36c31028"/*MidiNoteOutputExample*/,
+  "Description": "An example for the new MidiOutputNodes creating generative Music",
+  "InputUis": [],
+  "SymbolChildUis": [
+    {
+      "ChildId": "1bf38671-c3f7-4693-8af3-8e745d6b0f4c"/*Execute*/,
+      "Position": {
+        "X": 1230.8734,
+        "Y": 3.4378052
+      }
+    },
+    {
+      "ChildId": "077c96f1-a1d8-404b-b8d3-00652ba90fbe"/*RenderTarget*/,
+      "Position": {
+        "X": 1380.8734,
+        "Y": 3.4378052
+      }
+    },
+    {
+      "ChildId": "a8a4da22-2b04-4b69-9884-7f0242c11b96"/*MidiNoteOutput*/,
+      "Position": {
+        "X": 844.734,
+        "Y": 1.7948608
+      }
+    },
+    {
+      "ChildId": "9b4ee829-04a7-40e4-86e0-bc5e530a7646"/*MidiControlOutput*/,
+      "Position": {
+        "X": 844.734,
+        "Y": 83.79486
+      }
+    },
+    {
+      "ChildId": "75d47ec9-5a71-4b01-a2fe-7c986ed68128"/*MidiPitchbendOutput*/,
+      "Position": {
+        "X": 844.734,
+        "Y": 152.79486
+      }
+    },
+    {
+      "ChildId": "1862207a-335f-46c3-912a-f1d1058af8f8"/*PerlinNoise*/,
+      "Position": {
+        "X": 494.43176,
+        "Y": 53.293755
+      }
+    },
+    {
+      "ChildId": "ea70c0bf-8366-4398-8f3a-b7e001820631"/*FloatToInt*/,
+      "Position": {
+        "X": 644.43176,
+        "Y": 64.293755
+      }
+    },
+    {
+      "ChildId": "bf88e6f2-94b3-402c-bc28-58a0cb96c1df"/*AnimValue*/,
+      "Position": {
+        "X": 494.43176,
+        "Y": -58.706245
+      }
+    },
+    {
+      "ChildId": "15c61174-64e8-48b0-b0ff-11dc153b0242"/*PerlinNoise*/,
+      "Position": {
+        "X": 494.43176,
+        "Y": -2.7062454
+      }
+    },
+    {
+      "ChildId": "afd3e48a-5b41-4d0a-89ea-2ea940dfbd05"/*FloatToInt*/,
+      "Position": {
+        "X": 644.43176,
+        "Y": -2.7062454
+      }
+    },
+    {
+      "ChildId": "a2a6dffe-cf23-42ac-a671-ccd70c18ca43"/*Time*/,
+      "Position": {
+        "X": -333.14124,
+        "Y": 29.095764
+      }
+    },
+    {
+      "ChildId": "55e4e59c-d79e-4fba-a7fb-8f8b80b626c8"/*PerlinNoise*/,
+      "Position": {
+        "X": -141.67291,
+        "Y": -51.902504
+      }
+    },
+    {
+      "ChildId": "7cd70612-036e-4bb7-97f7-169c8c2fbadb"/*Accumulator*/,
+      "Position": {
+        "X": 8.32708,
+        "Y": -51.902504
+      }
+    },
+    {
+      "ChildId": "d2efdd50-5e2c-439c-965d-a2fc9d4193de"/*PerlinNoise*/,
+      "Position": {
+        "X": 494.43176,
+        "Y": 109.293755
+      }
+    },
+    {
+      "ChildId": "8407f8c0-df09-45e0-bb3d-83f9210403ee"/*FloatToInt*/,
+      "Position": {
+        "X": 644.43176,
+        "Y": 120.293755
+      }
+    },
+    {
+      "ChildId": "d05399ae-0e00-4178-a1d3-95341b85f89e"/*AnimValue*/,
+      "Position": {
+        "X": 187.93515,
+        "Y": 191.22797
+      }
+    },
+    {
+      "ChildId": "959c0b83-e17e-4ed0-bf46-d6c425b1f9ff"/*Spring*/,
+      "Position": {
+        "X": 644.43176,
+        "Y": 176.29376
+      }
+    },
+    {
+      "ChildId": "1756c6f3-c263-459d-92ce-e1a9cc3c1faf"/*PickFloat*/,
+      "Position": {
+        "X": 494.43176,
+        "Y": 165.29376
+      }
+    },
+    {
+      "ChildId": "80f073fe-da3b-40c3-8fd2-a0132b95f9e6"/*Value*/,
+      "Position": {
+        "X": 344.43176,
+        "Y": 165.29376
+      }
+    },
+    {
+      "ChildId": "f54a2058-0b89-459e-b285-58a1bb99c7ad"/*BoolToInt*/,
+      "Position": {
+        "X": 344.43176,
+        "Y": 208.29376
+      }
+    }
+  ],
+  "OutputUis": [
+    {
+      "OutputId": "3a972c37-fcf8-4c5f-b932-97ac9f6d5d99"/*ColorBuffer*/,
+      "Position": {
+        "X": 1530.8734,
+        "Y": 3.4378052
+      }
+    }
+  ],
+  "Annotations": [
+    {
+      "Id": "ce6b9168-d516-4ce5-a51a-2fa667cffa76",
+      "Title": "Be sure to set your output device!",
+      "Color": {
+        "X": 0.6,
+        "Y": 0.6,
+        "Z": 0.6,
+        "W": 1.0
+      },
+      "Position": {
+        "X": 809.07263,
+        "Y": -47.196106
+      },
+      "Size": {
+        "X": 384.6962,
+        "Y": 265.23218
+      }
+    },
+    {
+      "Id": "e2792d1a-9ee4-4063-bc5e-edcffe4da8b4",
+      "Title": "This example will send weird generative Midi notes to a Midi instrument you can select in the three output nodes.\nThe note pitch, speed, velocity and modwheel (CC1) are generated via PerlinNoise.\nThe pitch wheel is \"shaken\" randomly with a spring modifier.",
+      "Color": {
+        "X": 0.6,
+        "Y": 0.6,
+        "Z": 0.6,
+        "W": 1.0
+      },
+      "Position": {
+        "X": 489.4038,
+        "Y": -225.32672
+      },
+      "Size": {
+        "X": 834.9262,
+        "Y": 96.26842
+      }
+    }
+  ]
+}

--- a/Operators/Types/lib/io/midi/MidiControlOutput.cs
+++ b/Operators/Types/lib/io/midi/MidiControlOutput.cs
@@ -1,0 +1,232 @@
+using System;
+using System.Collections.Generic;
+using NAudio.Midi;
+using Operators.Utils;
+using T3.Core.Animation;
+using T3.Core.DataTypes;
+using T3.Core.Logging;
+using T3.Core.Operator;
+using T3.Core.Operator.Attributes;
+using T3.Core.Operator.Interfaces;
+using T3.Core.Operator.Slots;
+using T3.Core.Utils;
+
+namespace T3.Operators.Types.Id_a59c583b_dbc2_495c_a9b1_e64fc1e5d532 
+{
+    public class MidiControlOutput : Instance<MidiControlOutput>, MidiConnectionManager.IMidiConsumer, ICustomDropdownHolder,IStatusProvider
+    {
+        [Output(Guid = "2BDE4FD3-E74E-49C1-9FE5-867060067566")]
+        public readonly Slot<Command> Result = new();
+
+        public MidiControlOutput()
+        {
+            Result.UpdateAction = Update;
+        }
+
+        private bool _initialized;
+        protected override void Dispose(bool isDisposing)
+        {
+            if(!isDisposing) return;
+
+            if (_initialized)
+            {
+                MidiConnectionManager.UnregisterConsumer(this);
+            }
+        }
+        private void Update(EvaluationContext context)
+        {
+            var sendMode = SendMode.GetEnumValue<SendModes>(context);
+            var triggerActive = TriggerSend.GetValue(context);
+            var ccOrPressure = CCorPressure.GetEnumValue<DataTypes>(context);
+            var deviceName = Device.GetValue(context);
+            var foundDevice = false;
+            var controller = ControllerNumber.GetValue(context).Clamp(0, 127);
+
+
+            var useFloat = UseValueFloat.GetValue(context);
+            int intValue;
+            if (!useFloat)
+            {
+                intValue = Value.GetValue(context).Clamp(0, 127);
+            }
+            else
+            {
+                intValue = (int)(ValueFloat.GetValue(context).Clamp(0, 1) * 127);
+            }
+
+
+            if(!_initialized)
+            {
+                MidiConnectionManager.RegisterConsumer(this);
+                _initialized = true;
+            }
+
+            var triggerJustActivated = false;
+
+            if (triggerActive != _triggered)
+            {
+                if (triggerActive)
+                {
+                    triggerJustActivated = true;
+                }
+                _triggered = triggerActive;
+            }
+            
+            foreach (var (m, device) in MidiConnectionManager.MidiOutsWithDevices)
+            {
+                if (device.ProductName != deviceName)
+                    continue;
+                
+                var channel = ChannelNumber.GetValue(context).Clamp(1,16);
+                try
+                {
+                    MidiEvent midiEvent = null;
+                    switch (ccOrPressure)
+                    {
+                        case DataTypes.ContinuosController_CC:
+                            switch (sendMode)
+                            {
+                                case SendModes.SendWhenTriggered:
+                                    if (triggerJustActivated)
+                                    {
+                                        midiEvent = new ControlChangeEvent(0, channel, (MidiController)controller, intValue);
+                                    }
+                                    break;
+                                case SendModes.SendContinuously:
+                                    midiEvent = new ControlChangeEvent(0, channel, (MidiController)controller, intValue);
+                                    break;
+                            }
+                            break;
+
+                        case DataTypes.ChannelPressure:
+
+                            switch (sendMode)
+                            {
+                                case SendModes.SendWhenTriggered:
+                                    if (triggerJustActivated)
+                                    {
+                                        midiEvent = new ChannelAfterTouchEvent(0, channel, intValue);
+                                    }
+                                    break;
+                                case SendModes.SendContinuously:
+                                    midiEvent = new ChannelAfterTouchEvent(0, channel, intValue);
+                                    break;
+                            }
+                            break;
+                    }
+
+                    if (midiEvent != null)
+                        m.Send(midiEvent.GetAsShortMessage());
+                    
+                    //Log.Debug("Sending MidiTo " + device.Manufacturer + " " + device.ProductName, this);
+                    foundDevice = true;
+                    break;
+                }
+                catch (Exception e)
+                {
+                    _lastErrorMessage = $"Failed to send midi to {deviceName}: " + e.Message;
+                    Log.Warning(_lastErrorMessage, this);
+                }
+                
+            }
+            _lastErrorMessage = !foundDevice ? $"Can't find MidiDevice {deviceName}" : null;
+        }
+        
+        //private double _lastNoteOnTime;
+
+        private bool _triggered;
+
+        //private static int GetMicrosecondsPerQuarterNoteFromBpm(double bpm)
+        //{
+        //    var ms = 600000 / bpm;
+        //    return (int)ms;
+        //}
+        private enum SendModes
+        {
+            SendContinuously,
+            SendWhenTriggered
+        }
+        private enum DataTypes
+        {
+            ContinuosController_CC,
+            ChannelPressure
+        }
+
+
+        #region device dropdown
+
+        string ICustomDropdownHolder.GetValueForInput(Guid inputId)
+        {
+            return Device.Value;
+        }
+
+        IEnumerable<string> ICustomDropdownHolder.GetOptionsForInput(Guid inputId)
+        {
+            if (inputId != Device.Id)
+            {
+                yield return "undefined";
+                yield break;
+            }
+            
+            foreach (var device in MidiConnectionManager.MidiOutsWithDevices.Values)
+            {
+                yield return device.ProductName;
+            }
+        }
+
+        void ICustomDropdownHolder.HandleResultForInput(Guid inputId, string result)
+        {
+            Log.Debug($"Got {result}", this);
+            Device.SetTypedInputValue(result);
+        }
+        #endregion
+        
+        #region Implement statuslevel
+        IStatusProvider.StatusLevel IStatusProvider.GetStatusLevel()
+        {
+            return string.IsNullOrEmpty(_lastErrorMessage) ? IStatusProvider.StatusLevel.Success : IStatusProvider.StatusLevel.Error;
+        }
+
+        string IStatusProvider.GetStatusMessage()
+        {
+            return _lastErrorMessage;
+        }
+
+        // We don't actually receive midi in this operator, those methods can remain empty, we just want the MIDI connection thread up
+        public void MessageReceivedHandler(object sender, MidiInMessageEventArgs msg) {}
+
+        public void ErrorReceivedHandler(object sender, MidiInMessageEventArgs msg) {}
+
+        public void OnSettingsChanged() {}
+
+        private string _lastErrorMessage;
+        #endregion
+
+        [Input(Guid = "B8612A7D-CB19-4203-B5D0-A44CA71F5477", MappedType = typeof(SendModes))]
+        public readonly InputSlot<int> SendMode = new();
+
+        [Input(Guid = "5188CC2F-723C-497C-BFB8-1B00A3006327")]
+        public readonly InputSlot<bool> TriggerSend = new ();
+
+        [Input(Guid = "DC2F8501-2889-4949-9866-3C0EB43CD061", MappedType = typeof(DataTypes))]
+        public readonly InputSlot<int> CCorPressure = new();
+
+        [Input(Guid = "AFF6A747-7C3D-4CEF-A5B7-DAF9A60FCBA0")]
+        public readonly InputSlot<string> Device = new ();
+        
+        [Input(Guid = "B8C8F9D2-4EC9-4351-82AE-A17140BBE484")]
+        public readonly InputSlot<int> ChannelNumber = new ();
+
+        [Input(Guid = "083E3A73-4539-408E-A91A-1739CB4F3CC6")]
+        public readonly InputSlot<int> ControllerNumber = new();
+
+        [Input(Guid = "57096500-4EE4-4221-A7E7-1D2A065D01C8")]
+        public readonly InputSlot<int> Value = new ();
+
+        [Input(Guid = "F558C83A-2BA1-4CFE-BBF4-F5CBFDF68C73")]
+        public readonly InputSlot<bool> UseValueFloat = new();
+
+        [Input(Guid = "5734D4C9-1D84-4559-91D6-6611F0EA1658")]
+        public readonly InputSlot<float> ValueFloat = new ();
+    }
+}

--- a/Operators/Types/lib/io/midi/MidiControlOutput_a59c583b-dbc2-495c-a9b1-e64fc1e5d532.t3
+++ b/Operators/Types/lib/io/midi/MidiControlOutput_a59c583b-dbc2-495c-a9b1-e64fc1e5d532.t3
@@ -1,0 +1,45 @@
+{
+  "Name": "MidiControlOutput",
+  "Id": "a59c583b-dbc2-495c-a9b1-e64fc1e5d532",
+  "Namespace": "lib.io.midi",
+  "Inputs": [
+    {
+      "Id": "b8612a7d-cb19-4203-b5d0-a44ca71f5477"/*SendMode*/,
+      "DefaultValue": 0
+    },
+    {
+      "Id": "5188cc2f-723c-497c-bfb8-1b00a3006327"/*TriggerSend*/,
+      "DefaultValue": false
+    },
+    {
+      "Id": "dc2f8501-2889-4949-9866-3c0eb43cd061"/*CCorPressure*/,
+      "DefaultValue": 0
+    },
+    {
+      "Id": "aff6a747-7c3d-4cef-a5b7-daf9a60fcba0"/*Device*/,
+      "DefaultValue": ""
+    },
+    {
+      "Id": "b8c8f9d2-4ec9-4351-82ae-a17140bbe484"/*ChannelNumber*/,
+      "DefaultValue": 1
+    },
+    {
+      "Id": "083e3a73-4539-408e-a91a-1739cb4f3cc6"/*ControllerNumber*/,
+      "DefaultValue": 1
+    },
+    {
+      "Id": "57096500-4ee4-4221-a7e7-1d2a065d01c8"/*Value*/,
+      "DefaultValue": 0
+    },
+    {
+      "Id": "f558c83a-2ba1-4cfe-bbf4-f5cbfdf68c73"/*UseValueFloat*/,
+      "DefaultValue": false
+    },
+    {
+      "Id": "5734d4c9-1d84-4559-91d6-6611f0ea1658"/*ValueFloat*/,
+      "DefaultValue": 0.0
+    }
+  ],
+  "Children": [],
+  "Connections": []
+}

--- a/Operators/Types/lib/io/midi/MidiControlOutput_a59c583b-dbc2-495c-a9b1-e64fc1e5d532.t3ui
+++ b/Operators/Types/lib/io/midi/MidiControlOutput_a59c583b-dbc2-495c-a9b1-e64fc1e5d532.t3ui
@@ -1,0 +1,93 @@
+{
+  "Id": "a59c583b-dbc2-495c-a9b1-e64fc1e5d532"/*MidiControlOutput*/,
+  "Description": "Send 7 bit ControlChange or Channel Pressure events to the selected device. The value is given either as an integer value between 0 and 127 or as a normalized float value between 0.0 and 1.0.\n\nValues can either be sent continously (one value per frame) or only when the trigger input is sent a (temporary) boolean \"true\" value.\nSending continuously can lead to flooding of the receving device, so if possible, use the trigger option.\n\nYou can for instance use an [AnimValue]s \"WasHit\" output as the trigger and set it to a frequency that is sufficiently smooth for your purpose to reduce the load.\n\nThis node can be used in combination with [MidiNoteOutput] [MidiPitchbendOutput] and [MidiTriggerOutput] to create generative music or control hardware. See the [MidiNoteOutputExample]\n\nAKA: aftertouch, pressure, cc, controller",
+  "InputUis": [
+    {
+      "InputId": "b8612a7d-cb19-4203-b5d0-a44ca71f5477"/*SendMode*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 553.0
+      }
+    },
+    {
+      "InputId": "5188cc2f-723c-497c-bfb8-1b00a3006327"/*TriggerSend*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 598.0
+      }
+    },
+    {
+      "InputId": "dc2f8501-2889-4949-9866-3c0eb43cd061"/*CCorPressure*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 553.0
+      }
+    },
+    {
+      "InputId": "aff6a747-7c3d-4cef-a5b7-daf9a60fcba0"/*Device*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 508.0
+      },
+      "AddPadding": "True",
+      "Usage": "CustomDropdown"
+    },
+    {
+      "InputId": "b8c8f9d2-4ec9-4351-82ae-a17140bbe484"/*ChannelNumber*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 373.0
+      },
+      "Min": 1,
+      "Max": 16,
+      "Clamp": true
+    },
+    {
+      "InputId": "083e3a73-4539-408e-a91a-1739cb4f3cc6"/*ControllerNumber*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 373.0
+      },
+      "Min": 0,
+      "Max": 127,
+      "Clamp": true
+    },
+    {
+      "InputId": "57096500-4ee4-4221-a7e7-1d2a065d01c8"/*Value*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 778.0
+      },
+      "Min": 0,
+      "Max": 127,
+      "Clamp": true
+    },
+    {
+      "InputId": "f558c83a-2ba1-4cfe-bbf4-f5cbfdf68c73"/*UseValueFloat*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 778.0
+      }
+    },
+    {
+      "InputId": "5734d4c9-1d84-4559-91d6-6611f0ea1658"/*ValueFloat*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 778.0
+      },
+      "Min": 0.0,
+      "Max": 1.0,
+      "Clamp": true
+    }
+  ],
+  "SymbolChildUis": [],
+  "OutputUis": [
+    {
+      "OutputId": "2bde4fd3-e74e-49c1-9fe5-867060067566"/*Result*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 200.0
+      }
+    }
+  ]
+}

--- a/Operators/Types/lib/io/midi/MidiNoteOutput.cs
+++ b/Operators/Types/lib/io/midi/MidiNoteOutput.cs
@@ -1,0 +1,238 @@
+using System;
+using System.Collections.Generic;
+using NAudio.Midi;
+using Operators.Utils;
+using T3.Core.Animation;
+using T3.Core.DataTypes;
+using T3.Core.Logging;
+using T3.Core.Operator;
+using T3.Core.Operator.Attributes;
+using T3.Core.Operator.Interfaces;
+using T3.Core.Operator.Slots;
+using T3.Core.Utils;
+
+namespace T3.Operators.Types.Id_642cec4f_d4e0_4d0a_8dc3_6ca8339b5f89 
+{
+    public class MidiNoteOutput : Instance<MidiNoteOutput>, MidiConnectionManager.IMidiConsumer, ICustomDropdownHolder,IStatusProvider
+    {
+        [Output(Guid = "2CB961E5-C188-4190-B02B-753784CAFCA3")]
+        public readonly Slot<Command> Result = new();
+
+        public MidiNoteOutput()
+        {
+            Result.UpdateAction = Update;
+        }
+
+        private bool _initialized;
+        protected override void Dispose(bool isDisposing)
+        {
+            if(!isDisposing) return;
+
+            if (_initialized)
+            {
+                MidiConnectionManager.UnregisterConsumer(this);
+            }
+        }
+        private void Update(EvaluationContext context)
+        {
+            var triggerActive = TriggerSend.GetValue(context);
+            var sendMode = SendMode.GetEnumValue<SendModes>(context);
+            var deviceName = Device.GetValue(context);
+            var foundDevice = false;
+            var channel = ChannelNumber.GetValue(context).Clamp(1, 16);
+            var noteIndex = NoteNumber.GetValue(context).Clamp(0, 127);
+            var useFloatVelocity = UseVelocityFloat.GetValue(context);
+            var durationInMs = ((int)(DurationInSecs.GetValue(context)*1000)).Clamp(1, 100000);
+
+            int velocity;
+            if (useFloatVelocity)
+            {
+                velocity = (int)(VelocityFloat.GetValue(context).Clamp(0, 1) * 127);
+            }
+            else
+            {
+                velocity = Velocity.GetValue(context).Clamp(0, 127);
+            }
+
+            var triggerJustActivated = false;
+            var triggerJustDeactivated = false;
+
+            if(!_initialized)
+            {
+                MidiConnectionManager.RegisterConsumer(this);
+                _initialized = true;
+            }
+
+            if (triggerActive != _triggered)
+            {
+                if (triggerActive)
+                {
+                    triggerJustActivated = true;
+                }
+                else
+                {
+                    triggerJustDeactivated = true;
+                }
+
+                _triggered = triggerActive;
+            }
+
+            var absTime = (long)Playback.RunTimeInSecs * 1000;
+
+
+            foreach (var (m, device) in MidiConnectionManager.MidiOutsWithDevices)
+            {
+                if (device.ProductName != deviceName)
+                    continue;           
+                
+                try
+                {
+                    MidiEvent midiEvent =null;
+                    switch (sendMode)
+                    {
+                        case SendModes.Note_WhileTriggered:
+                            if (triggerJustActivated)
+                            {
+                                var noteOnEvent = new NoteOnEvent(0, channel, noteIndex, velocity, durationInMs);
+                                midiEvent = noteOnEvent;
+                                _offEvent = noteOnEvent.OffEvent;
+                            }
+                            else if (triggerJustDeactivated)
+                            {
+                                midiEvent = _offEvent;
+                                _offEvent = null;
+                            }
+                            break;
+                        
+                        case SendModes.Note_FixedDuration:
+                            if (triggerJustActivated)
+                            {
+                                if(_offEvent != null) 
+                                {
+                                    m.Send(_offEvent.GetAsShortMessage());
+                                    _offEvent = null;
+                                }
+                                var noteOnEvent = new NoteOnEvent(0, channel, noteIndex, velocity, durationInMs);
+                                midiEvent = noteOnEvent;
+                                _lastNoteOnTime = absTime;
+                                _offEvent = noteOnEvent.OffEvent;
+                            }
+                            else if (absTime - _lastNoteOnTime > durationInMs)
+                            {
+                                midiEvent = _offEvent;
+                                _offEvent = null;
+                            }
+                            break;
+                        
+                    }
+                    if(midiEvent != null)
+                        m.Send(midiEvent.GetAsShortMessage());
+                    
+                    foundDevice = true;
+                    break;
+                }
+                catch (Exception e)
+                {
+                    _lastErrorMessage = $"Failed to send midi to {deviceName}: " + e.Message;
+                    Log.Warning(_lastErrorMessage, this);
+                }
+                
+            }
+            _lastErrorMessage = !foundDevice ? $"Can't find MidiDevice {deviceName}" : null;
+        }
+        
+        private double _lastNoteOnTime;
+
+        private static int GetMicrosecondsPerQuarterNoteFromBpm(double bpm)
+        {
+            var ms = 600000 / bpm;
+            return (int)ms;
+        }
+
+        private enum SendModes
+        {
+            Note_FixedDuration,
+            Note_WhileTriggered,
+        }
+
+        private bool _triggered;
+
+        #region device dropdown
+        
+        string ICustomDropdownHolder.GetValueForInput(Guid inputId)
+        {
+            return Device.Value;
+        }
+
+        IEnumerable<string> ICustomDropdownHolder.GetOptionsForInput(Guid inputId)
+        {
+            if (inputId != Device.Id)
+            {
+                yield return "undefined";
+                yield break;
+            }
+            
+            foreach (var device in MidiConnectionManager.MidiOutsWithDevices.Values)
+            {
+                yield return device.ProductName;
+            }
+        }
+
+        void ICustomDropdownHolder.HandleResultForInput(Guid inputId, string result)
+        {
+            Log.Debug($"Got {result}", this);
+            Device.SetTypedInputValue(result);
+        }
+        #endregion
+        
+        #region Implement statuslevel
+        IStatusProvider.StatusLevel IStatusProvider.GetStatusLevel()
+        {
+            return string.IsNullOrEmpty(_lastErrorMessage) ? IStatusProvider.StatusLevel.Success : IStatusProvider.StatusLevel.Error;
+        }
+
+        string IStatusProvider.GetStatusMessage()
+        {
+            return _lastErrorMessage;
+        }
+
+        // We don't actually receive midi in this operator, those methods can remain empty, we just want the MIDI connection thread up
+        public void MessageReceivedHandler(object sender, MidiInMessageEventArgs msg) {}
+
+        public void ErrorReceivedHandler(object sender, MidiInMessageEventArgs msg) {}
+
+        public void OnSettingsChanged() {}
+
+        private string _lastErrorMessage;
+        #endregion
+        
+        [Input(Guid = "E1C1C77A-A6AF-4565-B345-F788BF268B2B")]
+        public readonly InputSlot<bool> TriggerSend = new ();        
+        
+        [Input(Guid = "0E9E5C88-5FA4-40E4-8B02-CA2E9510057F", MappedType = typeof(SendModes))]
+        public readonly InputSlot<int> SendMode = new ();
+
+        [Input(Guid = "97A4F0D3-E691-4C2C-B731-7E4AFC77EED2")]
+        public readonly InputSlot<string> Device = new ();
+        
+        [Input(Guid = "4B63108C-C5B7-42B9-ACDF-6BAC0E882D08")]
+        public readonly InputSlot<int> ChannelNumber = new ();
+
+        [Input(Guid = "90221C60-C7AC-4470-AFFB-E4FB22712EE5")]
+        public readonly InputSlot<int> NoteNumber = new ();
+
+        [Input(Guid = "A33619FA-BB33-4649-A714-285C5CCE15DC")]
+        public readonly InputSlot<int> Velocity = new ();
+
+        [Input(Guid = "B7ECA85F-3C35-43C3-9D79-2112D112C8C7")]
+        public readonly InputSlot<bool> UseVelocityFloat = new();
+
+        [Input(Guid = "5A99B601-328A-4238-9841-AB6022A932F5")]
+        public readonly InputSlot<float> VelocityFloat = new ();
+
+        [Input(Guid = "EDDB2482-F818-491B-A4E5-AF0E163DBA53")]
+        public readonly InputSlot<float> DurationInSecs = new ();
+
+        private NoteEvent _offEvent;
+    }
+}

--- a/Operators/Types/lib/io/midi/MidiNoteOutput_642cec4f-d4e0-4d0a-8dc3-6ca8339b5f89.t3
+++ b/Operators/Types/lib/io/midi/MidiNoteOutput_642cec4f-d4e0-4d0a-8dc3-6ca8339b5f89.t3
@@ -1,0 +1,45 @@
+{
+  "Name": "MidiNoteOutput",
+  "Id": "642cec4f-d4e0-4d0a-8dc3-6ca8339b5f89",
+  "Namespace": "lib.io.midi",
+  "Inputs": [
+    {
+      "Id": "e1c1c77a-a6af-4565-b345-f788bf268b2b"/*TriggerSend*/,
+      "DefaultValue": false
+    },
+    {
+      "Id": "0e9e5c88-5fa4-40e4-8b02-ca2e9510057f"/*SendMode*/,
+      "DefaultValue": 0
+    },
+    {
+      "Id": "97a4f0d3-e691-4c2c-b731-7e4afc77eed2"/*Device*/,
+      "DefaultValue": ""
+    },
+    {
+      "Id": "4b63108c-c5b7-42b9-acdf-6bac0e882d08"/*ChannelNumber*/,
+      "DefaultValue": 1
+    },
+    {
+      "Id": "90221c60-c7ac-4470-affb-e4fb22712ee5"/*NoteNumber*/,
+      "DefaultValue": 64
+    },
+    {
+      "Id": "a33619fa-bb33-4649-a714-285c5cce15dc"/*Velocity*/,
+      "DefaultValue": 100
+    },
+    {
+      "Id": "b7eca85f-3c35-43c3-9d79-2112d112c8c7"/*UseVelocityFloat*/,
+      "DefaultValue": false
+    },
+    {
+      "Id": "5a99b601-328a-4238-9841-ab6022a932f5"/*VelocityFloat*/,
+      "DefaultValue": 0.75
+    },
+    {
+      "Id": "eddb2482-f818-491b-a4e5-af0e163dba53"/*DurationInSecs*/,
+      "DefaultValue": 0.5
+    }
+  ],
+  "Children": [],
+  "Connections": []
+}

--- a/Operators/Types/lib/io/midi/MidiNoteOutput_642cec4f-d4e0-4d0a-8dc3-6ca8339b5f89.t3ui
+++ b/Operators/Types/lib/io/midi/MidiNoteOutput_642cec4f-d4e0-4d0a-8dc3-6ca8339b5f89.t3ui
@@ -1,0 +1,93 @@
+{
+  "Id": "642cec4f-d4e0-4d0a-8dc3-6ca8339b5f89"/*MidiNoteOutput*/,
+  "Description": "Send Midi notes to the selected device on the given channel. The velocity is provided either as an integer between 0 and 127 or as a normalized float value between 0.0 and 1.0\n\nWhen NoteWhileTriggered is selected, a note is played while the TriggerSend input is boolean \"true\". When it turns \"false\" a NoteOff command is sent to the receiving device.\nWhen NoteFixedDuration is selected, a note starts when the TriggerSend input is boolean \"true\" and ends after the time in DurationInSecs has passed or if another new note is triggered (to prevent overlapping or hanging notes).\n\nThis node can be used in combination with [MidiControlOutput], [MidiPitchbendOutput] and [MidiTriggerOutput] to create generative music or control hardware.",
+  "InputUis": [
+    {
+      "InputId": "e1c1c77a-a6af-4565-b345-f788bf268b2b"/*TriggerSend*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 598.0
+      }
+    },
+    {
+      "InputId": "0e9e5c88-5fa4-40e4-8b02-ca2e9510057f"/*SendMode*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 553.0
+      }
+    },
+    {
+      "InputId": "97a4f0d3-e691-4c2c-b731-7e4afc77eed2"/*Device*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 508.0
+      },
+      "AddPadding": "True",
+      "Usage": "CustomDropdown"
+    },
+    {
+      "InputId": "4b63108c-c5b7-42b9-acdf-6bac0e882d08"/*ChannelNumber*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 373.0
+      },
+      "Min": 1,
+      "Max": 16,
+      "Clamp": true
+    },
+    {
+      "InputId": "90221c60-c7ac-4470-affb-e4fb22712ee5"/*NoteNumber*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 418.0
+      },
+      "Min": 0,
+      "Max": 127,
+      "Clamp": true
+    },
+    {
+      "InputId": "a33619fa-bb33-4649-a714-285c5cce15dc"/*Velocity*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 688.0
+      },
+      "Min": 0,
+      "Max": 127,
+      "Clamp": true
+    },
+    {
+      "InputId": "b7eca85f-3c35-43c3-9d79-2112d112c8c7"/*UseVelocityFloat*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 778.0
+      }
+    },
+    {
+      "InputId": "5a99b601-328a-4238-9841-ab6022a932f5"/*VelocityFloat*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 733.0
+      },
+      "Min": 0.0,
+      "Max": 1.0,
+      "Clamp": true
+    },
+    {
+      "InputId": "eddb2482-f818-491b-a4e5-af0e163dba53"/*DurationInSecs*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 823.0
+      }
+    }
+  ],
+  "SymbolChildUis": [],
+  "OutputUis": [
+    {
+      "OutputId": "2cb961e5-c188-4190-b02b-753784cafca3"/*Result*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 200.0
+      }
+    }
+  ]
+}

--- a/Operators/Types/lib/io/midi/MidiPitchbendOutput.cs
+++ b/Operators/Types/lib/io/midi/MidiPitchbendOutput.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using NAudio.Midi;
+using Operators.Utils;
+using T3.Core.Animation;
+using T3.Core.DataTypes;
+using T3.Core.Logging;
+using T3.Core.Operator;
+using T3.Core.Operator.Attributes;
+using T3.Core.Operator.Interfaces;
+using T3.Core.Operator.Slots;
+using T3.Core.Utils;
+
+namespace T3.Operators.Types.Id_01d33d21_d75e_4c22_bfe6_088e1ee4a5e8 
+{
+    public class MidiPitchbendOutput : Instance<MidiPitchbendOutput>, MidiConnectionManager.IMidiConsumer, ICustomDropdownHolder,IStatusProvider
+    {
+        [Output(Guid = "402D1D43-5EAB-46F0-88C9-2C978E4223E8")]
+        public readonly Slot<Command> Result = new();
+
+        public MidiPitchbendOutput()
+        {
+            Result.UpdateAction = Update;
+        }
+
+        private bool _initialized;
+        protected override void Dispose(bool isDisposing)
+        {
+            if(!isDisposing) return;
+
+            if (_initialized)
+            {
+                MidiConnectionManager.UnregisterConsumer(this);
+            }
+        }
+        private void Update(EvaluationContext context)
+        {
+            var deviceName = Device.GetValue(context);
+            var foundDevice = false;
+
+            var useFloat = UsePitchFloat.GetValue(context);
+            int intPitch;
+            if (!useFloat)
+            {
+                intPitch = Pitch.GetValue(context).Clamp(-8192, 8191) + 8192;
+            }
+            else
+            {
+                intPitch = (int)((PitchFloat.GetValue(context).Clamp(-1, 1) * 8192.0).Clamp(-8192, 8191) + 8192);
+            }
+            var sendMode = SendMode.GetEnumValue<SendModes>(context);
+            var triggerActive = TriggerSend.GetValue(context);
+
+            var triggerJustActivated = false;
+
+            if(!_initialized)
+            {
+                MidiConnectionManager.RegisterConsumer(this);
+                _initialized = true;
+            }
+
+            if (triggerActive != _triggered)
+            {
+                if (triggerActive)
+                {
+                    triggerJustActivated = true;
+                }
+                _triggered = triggerActive;
+            }
+            
+            
+            foreach (var (m, device) in MidiConnectionManager.MidiOutsWithDevices)
+            {
+                if (device.ProductName != deviceName)
+                    continue;
+                
+                var channel = ChannelNumber.GetValue(context).Clamp(1,16);
+                try
+                {
+                    MidiEvent midiEvent = null;
+                    switch (sendMode)
+                    {
+                        case SendModes.SendWhenTriggered:
+                            if (triggerJustActivated)
+                            {
+                                midiEvent = new PitchWheelChangeEvent(0, channel, intPitch);
+                            }
+                            break;
+                        case SendModes.SendContinuously:
+                            midiEvent = new PitchWheelChangeEvent(0, channel, intPitch);
+                            break;
+                    }
+                    
+                    if (midiEvent != null)
+                        m.Send(midiEvent.GetAsShortMessage());
+                    
+                    //Log.Debug("Sending MidiTo " + device.Manufacturer + " " + device.ProductName, this);
+                    foundDevice = true;
+                    break;
+                }
+                catch (Exception e)
+                {
+                    _lastErrorMessage = $"Failed to send midi to {deviceName}: " + e.Message;
+                    Log.Warning(_lastErrorMessage, this);
+                }
+                
+            }
+            _lastErrorMessage = !foundDevice ? $"Can't find MidiDevice {deviceName}" : null;
+        }
+        
+        //private double _lastNoteOnTime;
+
+        private bool _triggered;
+
+        //private static int GetMicrosecondsPerQuarterNoteFromBpm(double bpm)
+        //{
+        //    var ms = 600000 / bpm;
+        //    return (int)ms;
+        //}
+        private enum SendModes
+        {
+            SendContinuously,
+            SendWhenTriggered
+        }
+
+
+        #region device dropdown
+        
+        string ICustomDropdownHolder.GetValueForInput(Guid inputId)
+        {
+            return Device.Value;
+        }
+
+        IEnumerable<string> ICustomDropdownHolder.GetOptionsForInput(Guid inputId)
+        {
+            if (inputId != Device.Id)
+            {
+                yield return "undefined";
+                yield break;
+            }
+            
+            foreach (var device in MidiConnectionManager.MidiOutsWithDevices.Values)
+            {
+                yield return device.ProductName;
+            }
+        }
+
+        void ICustomDropdownHolder.HandleResultForInput(Guid inputId, string result)
+        {
+            Log.Debug($"Got {result}", this);
+            Device.SetTypedInputValue(result);
+        }
+        #endregion
+        
+        #region Implement statuslevel
+        IStatusProvider.StatusLevel IStatusProvider.GetStatusLevel()
+        {
+            return string.IsNullOrEmpty(_lastErrorMessage) ? IStatusProvider.StatusLevel.Success : IStatusProvider.StatusLevel.Error;
+        }
+
+        string IStatusProvider.GetStatusMessage()
+        {
+            return _lastErrorMessage;
+        }
+
+        // We don't actually receive midi in this operator, those methods can remain empty, we just want the MIDI connection thread up
+        public void MessageReceivedHandler(object sender, MidiInMessageEventArgs msg) {}
+
+        public void ErrorReceivedHandler(object sender, MidiInMessageEventArgs msg) {}
+
+        public void OnSettingsChanged() {}
+
+        private string _lastErrorMessage;
+        #endregion
+
+        [Input(Guid = "5B25A41F-7609-4E19-98A2-1ECFAEB397BB", MappedType = typeof(SendModes))]
+        public readonly InputSlot<int> SendMode = new();
+
+        [Input(Guid = "E8665F67-9760-4289-AE2F-13665F63B4D8")]
+        public readonly InputSlot<bool> TriggerSend = new ();
+
+        [Input(Guid = "93868179-7D95-46C3-BD2C-8D6039AFEE69")]
+        public readonly InputSlot<string> Device = new ();
+        
+        [Input(Guid = "94F63571-52F4-45B8-A784-5556B4455F6A")]
+        public readonly InputSlot<int> ChannelNumber = new ();
+
+        [Input(Guid = "B9982ED7-C481-4508-A61E-229EAF5E960E")]
+        public readonly InputSlot<int> Pitch = new ();
+
+        [Input(Guid = "068A8EF1-9AA4-4E67-9700-5138358FA0B9")]
+        public readonly InputSlot<bool> UsePitchFloat = new();
+
+        [Input(Guid = "E92B7F08-18C6-402B-A4DC-BF553F881593")]
+        public readonly InputSlot<float> PitchFloat = new ();
+    }
+}

--- a/Operators/Types/lib/io/midi/MidiPitchbendOutput_01d33d21-d75e-4c22-bfe6-088e1ee4a5e8.t3
+++ b/Operators/Types/lib/io/midi/MidiPitchbendOutput_01d33d21-d75e-4c22-bfe6-088e1ee4a5e8.t3
@@ -1,0 +1,37 @@
+{
+  "Name": "MidiPitchbendOutput",
+  "Id": "01d33d21-d75e-4c22-bfe6-088e1ee4a5e8",
+  "Namespace": "lib.io.midi",
+  "Inputs": [
+    {
+      "Id": "5b25a41f-7609-4e19-98a2-1ecfaeb397bb"/*SendMode*/,
+      "DefaultValue": 0
+    },
+    {
+      "Id": "e8665f67-9760-4289-ae2f-13665f63b4d8"/*TriggerSend*/,
+      "DefaultValue": false
+    },
+    {
+      "Id": "93868179-7d95-46c3-bd2c-8d6039afee69"/*Device*/,
+      "DefaultValue": ""
+    },
+    {
+      "Id": "94f63571-52f4-45b8-a784-5556b4455f6a"/*ChannelNumber*/,
+      "DefaultValue": 1
+    },
+    {
+      "Id": "b9982ed7-c481-4508-a61e-229eaf5e960e"/*Pitch*/,
+      "DefaultValue": 0
+    },
+    {
+      "Id": "068a8ef1-9aa4-4e67-9700-5138358fa0b9"/*UsePitchFloat*/,
+      "DefaultValue": false
+    },
+    {
+      "Id": "e92b7f08-18c6-402b-a4dc-bf553f881593"/*PitchFloat*/,
+      "DefaultValue": 0.0
+    }
+  ],
+  "Children": [],
+  "Connections": []
+}

--- a/Operators/Types/lib/io/midi/MidiPitchbendOutput_01d33d21-d75e-4c22-bfe6-088e1ee4a5e8.t3ui
+++ b/Operators/Types/lib/io/midi/MidiPitchbendOutput_01d33d21-d75e-4c22-bfe6-088e1ee4a5e8.t3ui
@@ -1,0 +1,76 @@
+{
+  "Id": "01d33d21-d75e-4c22-bfe6-088e1ee4a5e8"/*MidiPitchbendOutput*/,
+  "Description": "Send 14 bit pitchbend events to the selected Device on the given Channel. The value can be provided either as an integer value between -8192 and 8191 or as a normalized float value between -1.0 and 1.0.\n\nValues can either be sent continously (one value per frame) or only when the trigger input is sent a (temporary) boolean \"true\" value.\nSending continuously can lead to flooding of the receving device, so if possible, use the trigger option.\n\nYou can for instance use an [AnimValue]s \"WasHit\" output and set it to a frequency that is sufficiently smooth for your purpose to reduce the load.\n\nThis node can be used in combination with [MidiNoteOutput] [MidiControlOutput] and [MidiTriggerOutput] to create generative music or control hardware. See the [MidiNoteOutputExample]\n\nAKA: pitch, pitchbend, transpose, detune",
+  "InputUis": [
+    {
+      "InputId": "5b25a41f-7609-4e19-98a2-1ecfaeb397bb"/*SendMode*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 553.0
+      }
+    },
+    {
+      "InputId": "e8665f67-9760-4289-ae2f-13665f63b4d8"/*TriggerSend*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 598.0
+      }
+    },
+    {
+      "InputId": "93868179-7d95-46c3-bd2c-8d6039afee69"/*Device*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 508.0
+      },
+      "AddPadding": "True",
+      "Usage": "CustomDropdown"
+    },
+    {
+      "InputId": "94f63571-52f4-45b8-a784-5556b4455f6a"/*ChannelNumber*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 373.0
+      },
+      "Min": 1,
+      "Max": 16,
+      "Clamp": true
+    },
+    {
+      "InputId": "b9982ed7-c481-4508-a61e-229eaf5e960e"/*Pitch*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 778.0
+      },
+      "Min": -8192,
+      "Max": 8191,
+      "Clamp": true
+    },
+    {
+      "InputId": "068a8ef1-9aa4-4e67-9700-5138358fa0b9"/*UsePitchFloat*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 778.0
+      }
+    },
+    {
+      "InputId": "e92b7f08-18c6-402b-a4dc-bf553f881593"/*PitchFloat*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 778.0
+      },
+      "Min": -1.0,
+      "Max": 1.0,
+      "Clamp": true
+    }
+  ],
+  "SymbolChildUis": [],
+  "OutputUis": [
+    {
+      "OutputId": "402d1d43-5eab-46f0-88c9-2c978e4223e8"/*Result*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 200.0
+      }
+    }
+  ]
+}

--- a/Operators/Types/lib/io/midi/MidiTriggerOutput.cs
+++ b/Operators/Types/lib/io/midi/MidiTriggerOutput.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Collections.Generic;
+using NAudio.Midi;
+using Operators.Utils;
+using T3.Core.Animation;
+using T3.Core.DataTypes;
+using T3.Core.Logging;
+using T3.Core.Operator;
+using T3.Core.Operator.Attributes;
+using T3.Core.Operator.Interfaces;
+using T3.Core.Operator.Slots;
+using T3.Core.Utils;
+namespace T3.Operators.Types.Id_61c11adb_94f0_4dc7_9611_c22c40709cf4
+{
+    public class MidiTriggerOutput : Instance<MidiTriggerOutput>, MidiConnectionManager.IMidiConsumer, ICustomDropdownHolder,IStatusProvider
+    {
+        [Output(Guid = "5E07FF38-A990-4BB7-B166-1A647F8C7933")]
+        public readonly Slot<Command> Result = new();
+
+        public MidiTriggerOutput()
+        {
+            Result.UpdateAction = Update;
+        }
+
+        private bool _initialized;
+        protected override void Dispose(bool isDisposing)
+        {
+            if(!isDisposing) return;
+
+            if (_initialized)
+            {
+                MidiConnectionManager.UnregisterConsumer(this);
+            }
+        }
+        private void Update(EvaluationContext context)
+        {
+            var deviceName = Device.GetValue(context);
+            var foundDevice = false;
+            var channel = ChannelNumber.GetValue(context).Clamp(1, 16);
+            var trigPC = TriggerProgramChange.GetValue(context);
+            var programChange = ProgramChangeNumber.GetValue(context).Clamp(0, 127);
+            var trigStart = TriggerStart.GetValue(context);
+            var trigStop = TriggerStop.GetValue(context);
+            var trigContinue = TriggerContinue.GetValue(context);
+            var trigTempo = TriggerTempoEvent.GetValue(context);
+
+            var activePC = false;
+            var activeStart = false;
+            var activeStop = false;
+            var activeContinue = false;
+            var activeTempo = false;
+
+
+            if (!_initialized)
+            {
+                MidiConnectionManager.RegisterConsumer(this);
+                _initialized = true;
+            }
+
+            //Only trigger once:
+
+            if (trigPC != _triggeredPC)
+            {
+                if (trigPC)
+                {
+                    activePC = true;
+                }
+                _triggeredPC = trigPC;
+            }
+
+            if (trigStart != _triggeredStart)
+            {
+                if (trigStart)
+                {
+                   activeStart = true;
+                }
+                _triggeredStart = trigStart;
+            }
+
+            if (trigStop != _triggeredStop)
+            {
+                if (trigStop)
+                {
+                    activeStop = true;
+                }
+                _triggeredStop = trigStop;
+            }
+
+            if (trigContinue != _triggeredContinue)
+            {
+                if (trigContinue)
+                {
+                    activeContinue = true;
+                }
+                _triggeredContinue = trigContinue;
+            }
+
+            if (trigTempo != _triggeredTempo)
+            {
+                if (trigTempo)
+                {
+                    activeTempo = true;
+                }
+                _triggeredTempo = trigTempo;
+            }
+
+
+            var absTime = (long)Playback.RunTimeInSecs * 1000;
+
+
+            foreach (var (m, device) in MidiConnectionManager.MidiOutsWithDevices)
+            {
+                if (device.ProductName != deviceName)
+                    continue;           
+                
+                try
+                {
+                    // In theory all can be triggered at once, therefore no case or if/else
+                    if(activePC)
+                    {
+                        m.Send(new PatchChangeEvent(0, channel, programChange).GetAsShortMessage());
+                    }
+                    if (activeStart)
+                    {
+                        m.Send(new MidiEvent(0, channel, MidiCommandCode.StartSequence).GetAsShortMessage());
+
+                    }
+                    if (activeStop)
+                    {
+                        m.Send(new MidiEvent(0, channel, MidiCommandCode.StopSequence).GetAsShortMessage());
+
+                    }
+                    if (activeContinue)
+                    {
+                        m.Send(new MidiEvent(0, channel, MidiCommandCode.ContinueSequence).GetAsShortMessage());
+
+                    }
+                    if (activeTempo)
+                    {
+                        m.Send(new TempoEvent(GetMicrosecondsPerQuarterNoteFromBpm(Playback.Current.Bpm), 0).GetAsShortMessage());
+
+                    }
+
+                    foundDevice = true;
+                }
+                catch (Exception e)
+                {
+                    _lastErrorMessage = $"Failed to send midi to {deviceName}: " + e.Message;
+                    Log.Warning(_lastErrorMessage, this);
+                }
+                
+            }
+            _lastErrorMessage = !foundDevice ? $"Can't find MidiDevice {deviceName}" : null;
+        }
+        
+        private static int GetMicrosecondsPerQuarterNoteFromBpm(double bpm)
+        {
+            var ms = 600000 / bpm;
+            return (int)ms;
+        }
+
+        private bool _triggeredPC;
+        private bool _triggeredStart;
+        private bool _triggeredStop;
+        private bool _triggeredContinue;
+        private bool _triggeredTempo;
+
+        #region device dropdown
+
+        string ICustomDropdownHolder.GetValueForInput(Guid inputId)
+        {
+            return Device.Value;
+        }
+
+        IEnumerable<string> ICustomDropdownHolder.GetOptionsForInput(Guid inputId)
+        {
+            if (inputId != Device.Id)
+            {
+                yield return "undefined";
+                yield break;
+            }
+            
+            foreach (var device in MidiConnectionManager.MidiOutsWithDevices.Values)
+            {
+                yield return device.ProductName;
+            }
+        }
+
+        void ICustomDropdownHolder.HandleResultForInput(Guid inputId, string result)
+        {
+            Log.Debug($"Got {result}", this);
+            Device.SetTypedInputValue(result);
+        }
+        #endregion
+        
+        #region Implement statuslevel
+        IStatusProvider.StatusLevel IStatusProvider.GetStatusLevel()
+        {
+            return string.IsNullOrEmpty(_lastErrorMessage) ? IStatusProvider.StatusLevel.Success : IStatusProvider.StatusLevel.Error;
+        }
+
+        string IStatusProvider.GetStatusMessage()
+        {
+            return _lastErrorMessage;
+        }
+
+        // We don't actually receive midi in this operator, those methods can remain empty, we just want the MIDI connection thread up
+        public void MessageReceivedHandler(object sender, MidiInMessageEventArgs msg) {}
+
+        public void ErrorReceivedHandler(object sender, MidiInMessageEventArgs msg) {}
+
+        public void OnSettingsChanged() {}
+
+        private string _lastErrorMessage;
+        #endregion
+        
+        [Input(Guid = "C134F57A-A40C-42E4-8223-5CD695B15CAA")]
+        public readonly InputSlot<string> Device = new ();
+        
+        [Input(Guid = "4B63108C-C5B7-42B9-ACDF-6BAC0E882D08")]
+        public readonly InputSlot<int> ChannelNumber = new ();
+
+        [Input(Guid = "5626D449-EF28-4D68-8805-014454F74F6B")]
+        public readonly InputSlot<bool> TriggerProgramChange = new ();
+
+        [Input(Guid = "90221C60-C7AC-4470-AFFB-E4FB22712EE5")]
+        public readonly InputSlot<int> ProgramChangeNumber = new ();
+
+        [Input(Guid = "8F5E7919-09AE-4D38-A404-93AD6D9EA6ED")]
+        public readonly InputSlot<bool> TriggerStart = new();
+
+        [Input(Guid = "09BB029E-5A17-4986-B2CB-94668C14C814")]
+        public readonly InputSlot<bool> TriggerStop = new();
+
+        [Input(Guid = "9A4DB45A-06DA-4C47-BFFF-860AAE8D9DFE")]
+        public readonly InputSlot<bool> TriggerContinue = new();
+
+        [Input(Guid = "7652082C-70B2-4FFE-88AA-63B9C323836F")]
+        public readonly InputSlot<bool> TriggerTempoEvent = new();
+    }
+}

--- a/Operators/Types/lib/io/midi/MidiTriggerOutput_61c11adb-94f0-4dc7-9611-c22c40709cf4.t3
+++ b/Operators/Types/lib/io/midi/MidiTriggerOutput_61c11adb-94f0-4dc7-9611-c22c40709cf4.t3
@@ -1,0 +1,41 @@
+{
+  "Name": "MidiTriggerOutput",
+  "Id": "61c11adb-94f0-4dc7-9611-c22c40709cf4",
+  "Namespace": "lib.io.midi",
+  "Inputs": [
+    {
+      "Id": "c134f57a-a40c-42e4-8223-5cd695b15caa"/*Device*/,
+      "DefaultValue": ""
+    },
+    {
+      "Id": "4b63108c-c5b7-42b9-acdf-6bac0e882d08"/*ChannelNumber*/,
+      "DefaultValue": 1
+    },
+    {
+      "Id": "5626d449-ef28-4d68-8805-014454f74f6b"/*TriggerProgramChange*/,
+      "DefaultValue": false
+    },
+    {
+      "Id": "90221c60-c7ac-4470-affb-e4fb22712ee5"/*ProgramChangeNumber*/,
+      "DefaultValue": 0
+    },
+    {
+      "Id": "8f5e7919-09ae-4d38-a404-93ad6d9ea6ed"/*TriggerStart*/,
+      "DefaultValue": false
+    },
+    {
+      "Id": "09bb029e-5a17-4986-b2cb-94668c14c814"/*TriggerStop*/,
+      "DefaultValue": false
+    },
+    {
+      "Id": "9a4db45a-06da-4c47-bfff-860aae8d9dfe"/*TriggerContinue*/,
+      "DefaultValue": false
+    },
+    {
+      "Id": "7652082c-70b2-4ffe-88aa-63b9c323836f"/*TriggerTempoEvent*/,
+      "DefaultValue": false
+    }
+  ],
+  "Children": [],
+  "Connections": []
+}

--- a/Operators/Types/lib/io/midi/MidiTriggerOutput_61c11adb-94f0-4dc7-9611-c22c40709cf4.t3ui
+++ b/Operators/Types/lib/io/midi/MidiTriggerOutput_61c11adb-94f0-4dc7-9611-c22c40709cf4.t3ui
@@ -1,0 +1,81 @@
+{
+  "Id": "61c11adb-94f0-4dc7-9611-c22c40709cf4"/*MidiTriggerOutput*/,
+  "Description": "Send ProgramChange or Sequencer commands to the selected Device on the chosen Channel. The ProgramChangeNumber is given as an integer between 0 and 127.\n\nAll parameters are sent when a trigger is received in the respective input.\nIt should only be a momentary, one frame long \"true\" value to not flood the receiving gear.\n\nBe aware that not many applications actually react to these triggers! Hardware is more likely to have them implemented.\n\nThis node can be used in combination with [MidiNoteOutput] [MidiControlOutput] and [MidiPitchbendOutput] to create generative music or control hardware.\n\nAKA: programchange, start, stop, continue, tempo, bpm",
+  "InputUis": [
+    {
+      "InputId": "c134f57a-a40c-42e4-8223-5cd695b15caa"/*Device*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 508.0
+      },
+      "AddPadding": "True",
+      "Usage": "CustomDropdown"
+    },
+    {
+      "InputId": "4b63108c-c5b7-42b9-acdf-6bac0e882d08"/*ChannelNumber*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 373.0
+      },
+      "Min": 1,
+      "Max": 16,
+      "Clamp": true
+    },
+    {
+      "InputId": "5626d449-ef28-4d68-8805-014454f74f6b"/*TriggerProgramChange*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 778.0
+      }
+    },
+    {
+      "InputId": "90221c60-c7ac-4470-affb-e4fb22712ee5"/*ProgramChangeNumber*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 418.0
+      },
+      "Min": 0,
+      "Max": 127,
+      "Clamp": true
+    },
+    {
+      "InputId": "8f5e7919-09ae-4d38-a404-93ad6d9ea6ed"/*TriggerStart*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 778.0
+      }
+    },
+    {
+      "InputId": "09bb029e-5a17-4986-b2cb-94668c14c814"/*TriggerStop*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 778.0
+      }
+    },
+    {
+      "InputId": "9a4db45a-06da-4c47-bfff-860aae8d9dfe"/*TriggerContinue*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 778.0
+      }
+    },
+    {
+      "InputId": "7652082c-70b2-4ffe-88aa-63b9c323836f"/*TriggerTempoEvent*/,
+      "Position": {
+        "X": 197.0,
+        "Y": 778.0
+      },
+      "Description": "This trigger sends Toolls current BPM value to the receiving device."
+    }
+  ],
+  "SymbolChildUis": [],
+  "OutputUis": [
+    {
+      "OutputId": "5e07ff38-a990-4bb7-b166-1a647f8c7933"/*Result*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 200.0
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Added four new MidiOutput nodes:

MidiNoteOutput, MidiControlOutput, MidiPitchbendOutput and MidiTriggerOutput
This will unclutter the interface and adds Channel Pressure, Pitchbend and Program Change.
The MidiNoteOutput now sends proper NoteOff commands and prevents hanging notes.