### PR TITLE
Green channel is driving Raster's GreenToLineWidth parameter

### DIFF
--- a/Resources/lib/img/fx/Raster.hlsl
+++ b/Resources/lib/img/fx/Raster.hlsl
@@ -100,7 +100,7 @@ float4 psMain(vsOutput psInput) : SV_TARGET
         float4 imgColorForCel = inputTexture.SampleLevel(texSampler, pCel, 0.0);
         // orgColor = imgColorForCel;
         dotSize = lerp(dotSize, imgColorForCel.r, RAffects_DotSize);
-        lineWidth = lerp(lineWidth, imgColorForCel.r, GAffects_LineWidth);
+        lineWidth = lerp(lineWidth, imgColorForCel.g, GAffects_LineWidth);
         lineRatio = lerp(lineRatio, imgColorForCel.b, BAffects_LineRatio);
         // return imgColorForCel;
     }


### PR DESCRIPTION
The Red channel was set to drive GreenToLineWidth parameter.
Now the Green channel is driving this parameter.