### PR TITLE
Alternative version of KeyboardInput 

### DIFF
--- a/Operators/Types/lib/io/input/KeyboardInput2.cs
+++ b/Operators/Types/lib/io/input/KeyboardInput2.cs
@@ -77,10 +77,21 @@ namespace T3.Operators.Types.Id_e3ddfd41_2d0b_4620_9f61_a201bbd25875
             }
         }
 
-        [Input(Guid = "2aa9e2e4-1830-4483-88e5-1f2ca50bfe3f")]
+        private enum Modes
+        {
+            IsDown,
+            KeepActive,
+        }
+        private enum Zones
+        {
+            NumRow,
+            Numpad,
+        }
+
+        [Input(Guid = "2aa9e2e4-1830-4483-88e5-1f2ca50bfe3f", MappedType = typeof(Zones))]
         public readonly InputSlot<int> Zone = new();
 
-        [Input(Guid = "8846aa50-e4d0-433c-9e5b-013a93f17f79")]
+        [Input(Guid = "8846aa50-e4d0-433c-9e5b-013a93f17f79", MappedType = typeof(Modes))]
         public readonly InputSlot<int> Mode = new();
     }
 }

--- a/Operators/Types/lib/io/input/KeyboardInput2.cs
+++ b/Operators/Types/lib/io/input/KeyboardInput2.cs
@@ -1,0 +1,86 @@
+using System;
+using T3.Core.IO;
+using T3.Core.Operator;
+using T3.Core.Operator.Attributes;
+using T3.Core.Operator.Slots;
+using T3.Core.Logging;
+using T3.Core.Operator.Interfaces;
+
+namespace T3.Operators.Types.Id_e3ddfd41_2d0b_4620_9f61_a201bbd25875
+{
+    public class KeyboardInput2 : Instance<KeyboardInput2>, IDisposable
+    {
+        [Output(Guid = "64B9DEC6-2B3A-4D7E-A174-991C8A8B92CE", DirtyFlagTrigger = DirtyFlagTrigger.Animated)]
+        public readonly Slot<int> PressedNumber = new();
+
+        
+
+        public KeyboardInput2()
+        {
+            PressedNumber.UpdateAction = Update;
+        }
+
+        private int _lastPressedNumber = 0;
+
+        private void Update(EvaluationContext context)
+        {
+            int currentZone = Zone.GetValue(context);
+            int currentMode = Mode.GetValue(context);
+            bool keyPressed = false;
+            int newPressedNumber = 0;
+
+            switch (currentZone)
+            {
+                case 0: // Number row keys (48-57)
+                    for (int i = 48; i <= 57; i++)
+                    {
+                        if (KeyHandler.PressedKeys[i])
+                        {
+                            newPressedNumber = i - 48;
+                            keyPressed = true;
+                            break;
+                        }
+                    }
+                    break;
+
+                case 1: // Numpad keys (96-105)
+                    for (int i = 96; i <= 105; i++)
+                    {
+                        if (KeyHandler.PressedKeys[i])
+                        {
+                            newPressedNumber = i - 96;
+                            keyPressed = true;
+                            break;
+                        }
+                    }
+                    break;
+            }
+
+            switch (currentMode)
+            {
+                case 0: // Original behavior - value is 0 when key is released
+                    PressedNumber.Value = keyPressed ? newPressedNumber : 0;
+                    _lastPressedNumber = PressedNumber.Value;
+                    break;
+
+                case 1: // Hold value - only update on new key press
+                    if (keyPressed && newPressedNumber != _lastPressedNumber)
+                    {
+                        _lastPressedNumber = newPressedNumber;
+                        PressedNumber.Value = newPressedNumber;
+                    }
+                    else if (!keyPressed)
+                    {
+                        PressedNumber.Value = _lastPressedNumber;
+                    }
+                    break;
+            }
+        }
+
+        [Input(Guid = "2aa9e2e4-1830-4483-88e5-1f2ca50bfe3f")]
+        public readonly InputSlot<int> Zone = new();
+
+        [Input(Guid = "8846aa50-e4d0-433c-9e5b-013a93f17f79")]
+        public readonly InputSlot<int> Mode = new();
+    }
+}

--- a/Operators/Types/lib/io/input/KeyboardInput2_e3ddfd41-2d0b-4620-9f61-a201bbd25875.t3
+++ b/Operators/Types/lib/io/input/KeyboardInput2_e3ddfd41-2d0b-4620-9f61-a201bbd25875.t3
@@ -1,0 +1,17 @@
+{
+  "Name": "KeyboardInput2",
+  "Id": "e3ddfd41-2d0b-4620-9f61-a201bbd25875",
+  "Namespace": "lib.io.input",
+  "Inputs": [
+    {
+      "Id": "2aa9e2e4-1830-4483-88e5-1f2ca50bfe3f"/*Zone*/,
+      "DefaultValue": 0
+    },
+    {
+      "Id": "8846aa50-e4d0-433c-9e5b-013a93f17f79"/*Mode*/,
+      "DefaultValue": 0
+    }
+  ],
+  "Children": [],
+  "Connections": []
+}

--- a/Operators/Types/lib/io/input/KeyboardInput2_e3ddfd41-2d0b-4620-9f61-a201bbd25875.t3ui
+++ b/Operators/Types/lib/io/input/KeyboardInput2_e3ddfd41-2d0b-4620-9f61-a201bbd25875.t3ui
@@ -1,0 +1,34 @@
+{
+  "Id": "e3ddfd41-2d0b-4620-9f61-a201bbd25875"/*KeyboardInput2*/,
+  "Description": "Works only for number keys, it returns a int value corresponding to the pressed key. Check parameters details.",
+  "InputUis": [
+    {
+      "InputId": "2aa9e2e4-1830-4483-88e5-1f2ca50bfe3f"/*Zone*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 0.0
+      },
+      "Description": "0: Top keyboard number keys\n1: Numpad"
+    },
+    {
+      "InputId": "8846aa50-e4d0-433c-9e5b-013a93f17f79"/*Mode*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 45.0
+      },
+      "Description": "0: only on down\n1: remains until an other key is pressed\n",
+      "Min": 0,
+      "Max": 1
+    }
+  ],
+  "SymbolChildUis": [],
+  "OutputUis": [
+    {
+      "OutputId": "64b9dec6-2b3a-4d7e-a174-991c8a8b92ce"/*PressedNumber*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 200.0
+      }
+    }
+  ]
+}

--- a/Operators/Types/lib/io/input/KeyboardInput2_e3ddfd41-2d0b-4620-9f61-a201bbd25875.t3ui
+++ b/Operators/Types/lib/io/input/KeyboardInput2_e3ddfd41-2d0b-4620-9f61-a201bbd25875.t3ui
@@ -1,14 +1,13 @@
 {
   "Id": "e3ddfd41-2d0b-4620-9f61-a201bbd25875"/*KeyboardInput2*/,
-  "Description": "Works only for number keys, it returns a int value corresponding to the pressed key. Check parameters details.",
+  "Description": "Works only for number keys, it returns a int value corresponding to the pressed key. Check parameters details.\nIt's useful combined with operators who use a int for selection such as [Switch], [PickTexture], [PickString], [PickFloat]...",
   "InputUis": [
     {
       "InputId": "2aa9e2e4-1830-4483-88e5-1f2ca50bfe3f"/*Zone*/,
       "Position": {
         "X": -200.0,
         "Y": 0.0
-      },
-      "Description": "0: Top keyboard number keys\n1: Numpad"
+      }
     },
     {
       "InputId": "8846aa50-e4d0-433c-9e5b-013a93f17f79"/*Mode*/,
@@ -16,7 +15,7 @@
         "X": -200.0,
         "Y": 45.0
       },
-      "Description": "0: only on down\n1: remains until an other key is pressed\n",
+      "Description": "IsDown: returns pressed key number until release \nKeepActive: remains until an other key is pressed\n",
       "Min": 0,
       "Max": 1
     }


### PR DESCRIPTION
This version gives access to the number keys from the top row of the keyboard and the numpad. It outputs the corresponding int value of the pressed key.

I'm using it to trigger the appearance of overlays while performing live.

A problem remains, I'm often using the numpad to enter values in the parameter window, then it triggers my overlays.
How can I avoid the register the pressed number keys while editing a setting value?