### PR TITLE
Fix for USB Microphones as external device

### DIFF
--- a/Core/Audio/WasapiAudioInput.cs
+++ b/Core/Audio/WasapiAudioInput.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using ManagedBass;
@@ -161,11 +161,10 @@ namespace T3.Core.Audio
 
         private static int Process(IntPtr buffer, int length, IntPtr user)
         {
-            //Log.Debug("Wasapi.Process() #1");
+            
+            //Log.Debug($"Wasapi.Process() called with buffer length: {length}");
             var level = BassWasapi.GetLevel();
-            if (length < 3000)
-                return length;
-
+            
             _lastUpdateTime = Playback.RunTimeInSecs;
 
             int resultCode;


### PR DESCRIPTION
Removing `if (length < 3000)` check fixes the issue because it ensures small buffers are not prematurely discarded.

Microphones, especially USB ones, often use smaller buffer sizes to provide low-latency audio. The 3000 threshold was prematurely skipping the processing of these small buffers, essentially discarding the input entirely.