### PR TITLE
TexCoord2 support for [DrawMesh] & [SetMaterial] 

### DIFF
--- a/Core/Rendering/Material/PbrMaterial.cs
+++ b/Core/Rendering/Material/PbrMaterial.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Numerics;
 using System.Runtime.InteropServices;
 using SharpDX.Direct3D11;
@@ -18,6 +18,7 @@ public class PbrMaterial: IDisposable
     public ShaderResourceView EmissiveMapSrv;
     public ShaderResourceView RoughnessMetallicOcclusionSrv;
     public ShaderResourceView NormalSrv;
+    public ShaderResourceView AlbedoMap2Srv;
 
     public PbrParameters Parameters;
     public Buffer ParameterBuffer;
@@ -65,7 +66,8 @@ public class PbrMaterial: IDisposable
         DefaultEmissiveColorSrv = new ShaderResourceView(ResourceManager.Device, PbrContextSettings.WhitePixelTexture);
         DefaultRoughnessMetallicOcclusionSrv = new ShaderResourceView(ResourceManager.Device, _defaultRmoTexture);
         DefaultNormalSrv = new ShaderResourceView(ResourceManager.Device, _defaultNormalTexture);
-        
+        DefaultAlbedoColor2Srv = WhitePixelSrv;
+
         var newMaterial= new PbrMaterial()
                              {
                                  Name = "Default",
@@ -74,8 +76,10 @@ public class PbrMaterial: IDisposable
                                  EmissiveMapSrv = DefaultEmissiveColorSrv,
                                  RoughnessMetallicOcclusionSrv = DefaultRoughnessMetallicOcclusionSrv,
                                  NormalSrv = DefaultNormalSrv,
+                                 AlbedoMap2Srv = DefaultAlbedoColor2Srv,
 
-                             };
+
+        };
         newMaterial.UpdateParameterBuffer();
         return newMaterial;
     }
@@ -95,7 +99,8 @@ public class PbrMaterial: IDisposable
     public static ShaderResourceView WhitePixelSrv;
     public static ShaderResourceView DefaultRoughnessMetallicOcclusionSrv;
     public static ShaderResourceView DefaultNormalSrv;
-    
+    public static ShaderResourceView DefaultAlbedoColor2Srv;
+
     public static Texture2D _defaultRmoTexture;
     public static Texture2D _defaultNormalTexture;
     
@@ -109,5 +114,6 @@ public class PbrMaterial: IDisposable
         RoughnessMetallicOcclusionSrv?.Dispose();
         NormalSrv?.Dispose();
         ParameterBuffer?.Dispose();
+        AlbedoMap2Srv?.Dispose();
     }
 }

--- a/Core/Rendering/Material/PbrMaterial.cs
+++ b/Core/Rendering/Material/PbrMaterial.cs
@@ -47,7 +47,7 @@ public class PbrMaterial: IDisposable
         public float Metal;
 
         [FieldOffset(11 * 4)]
-        private float __padding;
+        public float BlendMode;
 
         public const int Stride = 12 * 4;
     }
@@ -92,7 +92,8 @@ public class PbrMaterial: IDisposable
                                                                        EmissiveColor = new Vector4(0, 0, 0, 1),
                                                                        Roughness = 0.5f,
                                                                        Specular = 10,
-                                                                       Metal = 0
+                                                                       Metal = 0,
+                                                                       BlendMode = 0
                                                                    };
     public static ShaderResourceView DefaultEmissiveColorSrv;
     public static ShaderResourceView DefaultAlbedoColorSrv;

--- a/Operators/Types/lib/3d/draw/DrawMesh_a3c5471e-079b-4d4b-886a-ec02d6428ff6.t3
+++ b/Operators/Types/lib/3d/draw/DrawMesh_a3c5471e-079b-4d4b-886a-ec02d6428ff6.t3
@@ -497,6 +497,12 @@
       "TargetSlotId": "83fdb275-3018-46a9-b75e-e9ee3d8660f4"
     },
     {
+      "SourceParentOrChildId": "fb2a9567-d2b1-41df-a1ab-d855b1f94151",
+      "SourceSlotId": "2169fa1b-078f-44d6-adc2-7abf4ec2659b",
+      "TargetParentOrChildId": "69767494-70bc-4ac8-aa51-a552037edf79",
+      "TargetSlotId": "83fdb275-3018-46a9-b75e-e9ee3d8660f4"
+    },
+    {
       "SourceParentOrChildId": "2f12f5cb-cbdd-4d9a-b4ad-d2b577d2e965",
       "SourceSlotId": "7a76d147-4b8e-48cf-aa3e-aac3aa90e888",
       "TargetParentOrChildId": "69767494-70bc-4ac8-aa51-a552037edf79",

--- a/Operators/Types/lib/3d/draw/DrawMesh_a3c5471e-079b-4d4b-886a-ec02d6428ff6.t3ui
+++ b/Operators/Types/lib/3d/draw/DrawMesh_a3c5471e-079b-4d4b-886a-ec02d6428ff6.t3ui
@@ -269,8 +269,8 @@
     {
       "ChildId": "ef1f459a-d7ca-4c5a-9fa7-fcdfb1bb7f18"/*SrvFromTexture2d*/,
       "Position": {
-        "X": 2375.174,
-        "Y": 3881.7014
+        "X": 2373.569,
+        "Y": 3873.6758
       }
     },
     {

--- a/Operators/Types/lib/3d/mesh/modify/MeshProjectUV.cs
+++ b/Operators/Types/lib/3d/mesh/modify/MeshProjectUV.cs
@@ -37,6 +37,9 @@ namespace T3.Operators.Types.Id_97ffb173_f4cc_4143_a479_80cf3465cc7e
 
         [Input(Guid = "2ce29895-0bfd-4b73-ad57-50aca7fd1a96")]
         public readonly InputSlot<float> Scale = new();
+
+        [Input(Guid = "14e8cc1a-0fee-4162-9192-45b635e154a8")]
+        public readonly InputSlot<bool> TexCoord2 = new InputSlot<bool>();
     }
 }
 

--- a/Operators/Types/lib/3d/mesh/modify/MeshProjectUV_97ffb173-f4cc-4143-a479-80cf3465cc7e.t3
+++ b/Operators/Types/lib/3d/mesh/modify/MeshProjectUV_97ffb173-f4cc-4143-a479-80cf3465cc7e.t3
@@ -34,6 +34,10 @@
     {
       "Id": "2ce29895-0bfd-4b73-ad57-50aca7fd1a96"/*Scale*/,
       "DefaultValue": 1.0
+    },
+    {
+      "Id": "14e8cc1a-0fee-4162-9192-45b635e154a8"/*TexCoord2*/,
+      "DefaultValue": false
     }
   ],
   "Children": [
@@ -377,6 +381,12 @@
       "SymbolId": "646d6a5d-a1d7-471e-86ab-e1fb2542a2c2",
       "InputValues": [],
       "Outputs": []
+    },
+    {
+      "Id": "10241097-0d17-4090-b2e1-f821a31c12fe"/*BoolToFloat*/,
+      "SymbolId": "9db2fcbf-54b9-4222-878b-80d1a0dc6edf",
+      "InputValues": [],
+      "Outputs": []
     }
   ],
   "Connections": [
@@ -385,6 +395,12 @@
       "SourceSlotId": "d71893dd-6ca2-4ab7-9e04-0bd7285eccfb",
       "TargetParentOrChildId": "00000000-0000-0000-0000-000000000000",
       "TargetSlotId": "84c6619e-4264-4d16-b870-5413d986f08a"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "14e8cc1a-0fee-4162-9192-45b635e154a8",
+      "TargetParentOrChildId": "10241097-0d17-4090-b2e1-f821a31c12fe",
+      "TargetSlotId": "253b9ae4-fac5-4641-bf0c-d8614606a840"
     },
     {
       "SourceParentOrChildId": "43ffb9c8-0961-4ec4-bc3c-7f7f6b4e4b23",
@@ -707,6 +723,12 @@
     {
       "SourceParentOrChildId": "4af20b14-9dcf-4d0a-a7c8-94072e09a37e",
       "SourceSlotId": "c5ea9711-6326-4edc-932b-35fd11323e4f",
+      "TargetParentOrChildId": "b5b60e5f-b096-4c24-9da1-25303395888f",
+      "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
+    },
+    {
+      "SourceParentOrChildId": "10241097-0d17-4090-b2e1-f821a31c12fe",
+      "SourceSlotId": "f0321a54-e844-482f-a161-7f137abc54b0",
       "TargetParentOrChildId": "b5b60e5f-b096-4c24-9da1-25303395888f",
       "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
     },

--- a/Operators/Types/lib/3d/mesh/modify/MeshProjectUV_97ffb173-f4cc-4143-a479-80cf3465cc7e.t3ui
+++ b/Operators/Types/lib/3d/mesh/modify/MeshProjectUV_97ffb173-f4cc-4143-a479-80cf3465cc7e.t3ui
@@ -40,6 +40,13 @@
         "Y": 1105.2872
       },
       "Description": "Uniformly scales the mapping"
+    },
+    {
+      "InputId": "14e8cc1a-0fee-4162-9192-45b635e154a8"/*TexCoord2*/,
+      "Position": {
+        "X": -1598.1094,
+        "Y": 1150.2872
+      }
     }
   ],
   "SymbolChildUis": [
@@ -319,6 +326,13 @@
       "Position": {
         "X": -1184.6838,
         "Y": 620.65784
+      }
+    },
+    {
+      "ChildId": "10241097-0d17-4090-b2e1-f821a31c12fe"/*BoolToFloat*/,
+      "Position": {
+        "X": -664.0912,
+        "Y": 1370.3538
       }
     }
   ],

--- a/Operators/Types/lib/3d/rendering/SetMaterial.cs
+++ b/Operators/Types/lib/3d/rendering/SetMaterial.cs
@@ -53,7 +53,7 @@ namespace T3.Operators.Types.Id_0ed2bee3_641f_4b08_8685_df1506e9af3c
             UpdateSrv(NormalMap, context, ref _pbrMaterial.NormalSrv, PbrMaterial.DefaultNormalSrv);
             UpdateSrv(EmissiveColorMap, context, ref _pbrMaterial.EmissiveMapSrv, PbrMaterial.DefaultEmissiveColorSrv);
             UpdateSrv(RoughnessMetallicOcclusionMap, context, ref _pbrMaterial.RoughnessMetallicOcclusionSrv, PbrMaterial.DefaultRoughnessMetallicOcclusionSrv);
-
+            UpdateSrv(BaseColorMap2, context, ref _pbrMaterial.AlbedoMap2Srv, PbrMaterial.DefaultAlbedoColor2Srv);
             var previousMaterial = context.PbrMaterial;
             context.PbrMaterial = _pbrMaterial;
             
@@ -143,6 +143,9 @@ namespace T3.Operators.Types.Id_0ed2bee3_641f_4b08_8685_df1506e9af3c
 
         [Input(Guid = "71E289F0-382B-4D0F-A2E0-701C7019A360")]
         public readonly InputSlot<string> MaterialId = new();
+
+        [Input(Guid = "c3df717c-822a-4aae-a5a8-a27e4d98fda8")]
+        public readonly InputSlot<Texture2D> BaseColorMap2 = new();
 
 
     }

--- a/Operators/Types/lib/3d/rendering/SetMaterial.cs
+++ b/Operators/Types/lib/3d/rendering/SetMaterial.cs
@@ -34,6 +34,7 @@ namespace T3.Operators.Types.Id_0ed2bee3_641f_4b08_8685_df1506e9af3c
                                              Roughness.DirtyFlag.IsDirty ||
                                              Specular.DirtyFlag.IsDirty ||
                                              Metal.DirtyFlag.IsDirty ||
+                                             BlendMode.DirtyFlag.IsDirty ||
                                              _pbrMaterial == null;
             
             _pbrMaterial ??= new PbrMaterial();
@@ -45,6 +46,7 @@ namespace T3.Operators.Types.Id_0ed2bee3_641f_4b08_8685_df1506e9af3c
                 _pbrMaterial.Parameters.Roughness = Roughness.GetValue(context);
                 _pbrMaterial.Parameters.Specular = Specular.GetValue(context);
                 _pbrMaterial.Parameters.Metal = Metal.GetValue(context);
+                _pbrMaterial.Parameters.BlendMode = BlendMode.GetValue(context);
 
                 _pbrMaterial.UpdateParameterBuffer();
             }
@@ -146,6 +148,9 @@ namespace T3.Operators.Types.Id_0ed2bee3_641f_4b08_8685_df1506e9af3c
 
         [Input(Guid = "c3df717c-822a-4aae-a5a8-a27e4d98fda8")]
         public readonly InputSlot<Texture2D> BaseColorMap2 = new();
+
+        [Input(Guid = "f574046e-e10b-42e2-84af-8b28759ba636", MappedType = typeof(SharedEnums.RgbBlendModes))]
+        public readonly InputSlot<int> BlendMode = new();
 
 
     }

--- a/Operators/Types/lib/3d/rendering/SetMaterial_0ed2bee3-641f-4b08-8685-df1506e9af3c.t3
+++ b/Operators/Types/lib/3d/rendering/SetMaterial_0ed2bee3-641f-4b08-8685-df1506e9af3c.t3
@@ -60,6 +60,10 @@
     {
       "Id": "c3df717c-822a-4aae-a5a8-a27e4d98fda8"/*BaseColorMap2*/,
       "DefaultValue": null
+    },
+    {
+      "Id": "f574046e-e10b-42e2-84af-8b28759ba636"/*BlendMode*/,
+      "DefaultValue": 0
     }
   ],
   "Children": [],

--- a/Operators/Types/lib/3d/rendering/SetMaterial_0ed2bee3-641f-4b08-8685-df1506e9af3c.t3
+++ b/Operators/Types/lib/3d/rendering/SetMaterial_0ed2bee3-641f-4b08-8685-df1506e9af3c.t3
@@ -56,6 +56,10 @@
     {
       "Id": "71e289f0-382b-4d0f-a2e0-701c7019a360"/*MaterialId*/,
       "DefaultValue": ""
+    },
+    {
+      "Id": "c3df717c-822a-4aae-a5a8-a27e4d98fda8"/*BaseColorMap2*/,
+      "DefaultValue": null
     }
   ],
   "Children": [],

--- a/Operators/Types/lib/3d/rendering/SetMaterial_0ed2bee3-641f-4b08-8685-df1506e9af3c.t3ui
+++ b/Operators/Types/lib/3d/rendering/SetMaterial_0ed2bee3-641f-4b08-8685-df1506e9af3c.t3ui
@@ -105,6 +105,13 @@
         "Y": 450.0
       },
       "GroupTitle": "2nd UV Map / TexCoord2"
+    },
+    {
+      "InputId": "f574046e-e10b-42e2-84af-8b28759ba636"/*BlendMode*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 495.0
+      }
     }
   ],
   "SymbolChildUis": [],

--- a/Operators/Types/lib/3d/rendering/SetMaterial_0ed2bee3-641f-4b08-8685-df1506e9af3c.t3ui
+++ b/Operators/Types/lib/3d/rendering/SetMaterial_0ed2bee3-641f-4b08-8685-df1506e9af3c.t3ui
@@ -103,7 +103,8 @@
       "Position": {
         "X": -200.0,
         "Y": 450.0
-      }
+      },
+      "GroupTitle": "2nd UV Map / TexCoord2"
     }
   ],
   "SymbolChildUis": [],

--- a/Operators/Types/lib/3d/rendering/SetMaterial_0ed2bee3-641f-4b08-8685-df1506e9af3c.t3ui
+++ b/Operators/Types/lib/3d/rendering/SetMaterial_0ed2bee3-641f-4b08-8685-df1506e9af3c.t3ui
@@ -97,6 +97,13 @@
       },
       "Description": "ID used in context with [LoadGltfScene] and [DefineMaterials]",
       "Usage": "Default"
+    },
+    {
+      "InputId": "c3df717c-822a-4aae-a5a8-a27e4d98fda8"/*BaseColorMap2*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 450.0
+      }
     }
   ],
   "SymbolChildUis": [],

--- a/Operators/Types/lib/3d/rendering/_/GetPbrParameters.cs
+++ b/Operators/Types/lib/3d/rendering/_/GetPbrParameters.cs
@@ -28,6 +28,9 @@ namespace T3.Operators.Types.Id_ca4fe8c4_cf61_4196_84e4_d69dc8869a25
         
         [Output(Guid = "AB644673-9EAA-4CEC-9663-FBFDC445D112", DirtyFlagTrigger = DirtyFlagTrigger.Always)]
         public readonly Slot<Texture2D> PrefilteredSpecularMap = new();
+
+        [Output(Guid = "2169fa1b-078f-44d6-adc2-7abf4ec2659b")]
+        public readonly Slot<SharpDX.Direct3D11.ShaderResourceView> AlbedoColorMap2 = new Slot<SharpDX.Direct3D11.ShaderResourceView>();
         
         public GetPbrParameters()
         {

--- a/Operators/Types/lib/3d/rendering/_/GetPbrParameters.cs
+++ b/Operators/Types/lib/3d/rendering/_/GetPbrParameters.cs
@@ -29,8 +29,8 @@ namespace T3.Operators.Types.Id_ca4fe8c4_cf61_4196_84e4_d69dc8869a25
         [Output(Guid = "AB644673-9EAA-4CEC-9663-FBFDC445D112", DirtyFlagTrigger = DirtyFlagTrigger.Always)]
         public readonly Slot<Texture2D> PrefilteredSpecularMap = new();
 
-        [Output(Guid = "2169fa1b-078f-44d6-adc2-7abf4ec2659b")]
-        public readonly Slot<SharpDX.Direct3D11.ShaderResourceView> AlbedoColorMap2 = new Slot<SharpDX.Direct3D11.ShaderResourceView>();
+        [Output(Guid = "2169fa1b-078f-44d6-adc2-7abf4ec2659b", DirtyFlagTrigger = DirtyFlagTrigger.Always)]
+        public readonly Slot<ShaderResourceView> AlbedoColorMap2 = new();
         
         public GetPbrParameters()
         {
@@ -41,6 +41,7 @@ namespace T3.Operators.Types.Id_ca4fe8c4_cf61_4196_84e4_d69dc8869a25
             NormalMap.UpdateAction = UpdateNormalMap;
             BrdfLookupMap.UpdateAction = UpdateBrdfLookupMap;
             PrefilteredSpecularMap.UpdateAction = UpdatePrefilteredSpecularMap;
+            AlbedoColorMap2.UpdateAction = UpdateAlbedoColorMap2;
         }
 
         
@@ -50,6 +51,7 @@ namespace T3.Operators.Types.Id_ca4fe8c4_cf61_4196_84e4_d69dc8869a25
         private void UpdateRoughnessMetallicOcclusionMap(EvaluationContext context) => RoughnessMetallicOcclusionMap.Value = context.PbrMaterial.RoughnessMetallicOcclusionSrv;
         private void UpdateNormalMap(EvaluationContext context) => NormalMap.Value = context.PbrMaterial.NormalSrv;
         private void UpdateBrdfLookupMap(EvaluationContext context) => BrdfLookupMap.Value = PbrContextSettings.PbrLookUpTextureSrv;
+        private void UpdateAlbedoColorMap2(EvaluationContext context) => AlbedoColorMap2.Value = context.PbrMaterial.AlbedoMap2Srv;
 
         private void UpdatePrefilteredSpecularMap(EvaluationContext context)
         {

--- a/Operators/Types/lib/3d/rendering/_/GetPbrParameters_ca4fe8c4-cf61-4196-84e4-d69dc8869a25.t3ui
+++ b/Operators/Types/lib/3d/rendering/_/GetPbrParameters_ca4fe8c4-cf61-4196-84e4-d69dc8869a25.t3ui
@@ -7,29 +7,29 @@
     {
       "OutputId": "3d2ebd10-2670-46b7-8f1a-9475a81a516d"/*PbrParameterBuffer*/,
       "Position": {
-        "X": 0.0,
-        "Y": 0.0
+        "X": -2.4299011,
+        "Y": -34.01869
       }
     },
     {
       "OutputId": "7c3d08e2-85e2-442a-9196-0e946571da5a"/*AlbedoColorMap*/,
       "Position": {
-        "X": 0.0,
-        "Y": 0.0
+        "X": 8.099686,
+        "Y": 39.68847
       }
     },
     {
       "OutputId": "b6bad091-131a-49f3-8acc-7011a4919435"/*EmissiveColorMap*/,
       "Position": {
-        "X": 0.0,
-        "Y": 0.0
+        "X": 127.57008,
+        "Y": 8.504677
       }
     },
     {
       "OutputId": "b48f674b-2b5a-4501-992e-26e07a247ddf"/*RoughnessMetallicOcclusionMap*/,
       "Position": {
-        "X": 0.0,
-        "Y": 0.0
+        "X": 127.165115,
+        "Y": 66.01246
       }
     },
     {
@@ -49,8 +49,15 @@
     {
       "OutputId": "ab644673-9eaa-4cec-9663-fbfdc445d112"/*PrefilteredSpecularMap*/,
       "Position": {
-        "X": 0.0,
-        "Y": 200.0
+        "X": -3.6448593,
+        "Y": 162.33646
+      }
+    },
+    {
+      "OutputId": "2169fa1b-078f-44d6-adc2-7abf4ec2659b"/*AlbedoColorMap2*/,
+      "Position": {
+        "X": 127.57008,
+        "Y": 262.33646
       }
     }
   ]

--- a/Resources/lib/3d/mesh/fx/mesh-UVs.hlsl
+++ b/Resources/lib/3d/mesh/fx/mesh-UVs.hlsl
@@ -44,5 +44,6 @@ RWStructuredBuffer<PbrVertex> ResultVertices : u0; // output
     ResultVertices[i.x].Tangent = lerp(A.Tangent, float3(1,0,0), f);
     ResultVertices[i.x].Bitangent = lerp(A.Bitangent, float3(0,1,0), f);
     ResultVertices[i.x].TexCoord = A.TexCoord;
+    ResultVertices[i.x].TexCoord2 = A.TexCoord2;
     ResultVertices[i.x].Selected = A.Selected;
 }

--- a/Resources/lib/3d/mesh/mesh-Draw.hlsl
+++ b/Resources/lib/3d/mesh/mesh-Draw.hlsl
@@ -124,8 +124,8 @@ float4 psMain(psInput pin) : SV_TARGET
     
 
     //albedo.rgb = 1 - (1 - albedo.rgb) * (1 - albedo2.rgb * albedo2.a);
-    albedo.rgb = (1.0 - albedo2.a) * albedo.rgb + albedo2.a * albedo2.rgb;
-   
+    //albedo.rgb = (1.0 - albedo2.a) * albedo.rgb + albedo2.a * albedo2.rgb;
+    albedo.rgb = albedo.rgb * albedo2.rgb;
     if (AlphaCutOff > 0 && albedo.a < AlphaCutOff)
     {
         discard;

--- a/Resources/lib/3d/mesh/mesh-Draw.hlsl
+++ b/Resources/lib/3d/mesh/mesh-Draw.hlsl
@@ -120,11 +120,12 @@ float4 psMain(psInput pin) : SV_TARGET
 {
     // Sample input textures to get shading model params.
     float4 albedo = BaseColorMap.Sample(texSampler, pin.texCoord);
+    float4 albedo2 = BaseColorMap2.Sample(texSampler2, pin.texCoord2);
     
 
     //albedo.rgb = 1 - (1 - albedo.rgb) * (1 - albedo2.rgb * albedo2.a);
-
-    BaseColorMap.Sample(texSampler, pin.texCoord);
+    albedo.rgb = (1.0 - albedo2.a) * albedo.rgb + albedo2.a * albedo2.rgb;
+   
     if (AlphaCutOff > 0 && albedo.a < AlphaCutOff)
     {
         discard;
@@ -231,7 +232,7 @@ float4 psMain(psInput pin) : SV_TARGET
     }
 
     // Final fragment color.
-    float4 albedo2 = BaseColorMap2.Sample(texSampler2, pin.texCoord2)* BaseColor;
+    
     float4 litColor = float4(directLighting + ambientLighting, 1.0) * BaseColor * Color;
     litColor += float4(EmissiveColorMap.Sample(texSampler2, pin.texCoord2).rgb * EmissiveColor.rgb, 0);
     litColor.rgb = lerp(litColor.rgb, FogColor.rgb, pin.fog * FogColor.a);

--- a/Resources/lib/3d/mesh/mesh-ProjectUV.hlsl
+++ b/Resources/lib/3d/mesh/mesh-ProjectUV.hlsl
@@ -19,6 +19,7 @@ cbuffer Transforms : register(b0)
 cbuffer Params : register(b1)
 {
     float4x4 Transform;
+    float TexCoord2;
 }
 
 
@@ -47,7 +48,12 @@ void main(uint3 i : SV_DispatchThreadID)
     //float4x4 orientationMatrix = transpose(qToMatrix(p.rotation));
     //float4x4 t = Transform;
     //t=transpose(t);
-
-    v.TexCoord = mul( float4(posInObject.xyz,1), Transform).xy;
+    if ((bool)TexCoord2==true){
+      v.TexCoord2 = mul( float4(posInObject.xyz,1), Transform).xy + float2(1,1); 
+    }
+    else{
+        v.TexCoord = mul( float4(posInObject.xyz,1), Transform).xy + float2(1,1);
+    }
+   
     ResultVertices[vertexIndex] = v;
 }


### PR DESCRIPTION
Since I've updated the PBR struct for [DisplaceMeshVAT], a mesh can have a second set of texture coordinates. 
 

https://github.com/user-attachments/assets/e61e3357-db5f-4017-9f5c-20bb4f0ff6f7

Todo :

- [x] support for shared Blend-function.hlsl
- [ ] TexCoord switches for the different textures
- [ ] trying to not over bloat [SetMaterial] 