### PR TITLE
Alternative uv map for CubeMesh

### DIFF
--- a/Operators/Lib/mesh/generate/CubeMesh.t3
+++ b/Operators/Lib/mesh/generate/CubeMesh.t3
@@ -1,51 +1,55 @@
 {
   "Id": "c47ab830-aae7-4f8f-b67c-9119bcbaf7df"/*CubeMesh*/,
-  "Inputs": [
-    {
-      "Id": "97c9849e-751c-49a9-823d-0af839fa503e"/*Stretch*/,
-      "DefaultValue": {
-        "X": 1.0,
-        "Y": 1.0,
-        "Z": 1.0
-      }
-    },
-    {
-      "Id": "9a7d34a1-ca39-48bc-b977-9a786d23f3b1"/*Scale*/,
-      "DefaultValue": 1.0
-    },
-    {
-      "Id": "e445a6da-0b66-46ae-ad2b-650e9cc50798"/*Segments*/,
-      "DefaultValue": {
-        "X": 1,
-        "Y": 1,
-        "Z": 1
-      }
-    },
-    {
-      "Id": "e641c244-9dc8-444d-8dee-c3e9b710f9db"/*Rotation*/,
-      "DefaultValue": {
-        "X": 0.0,
-        "Y": 0.0,
-        "Z": 0.0
-      }
-    },
-    {
-      "Id": "f4a78f77-8d8c-4b7b-8545-ea80947b428d"/*Center*/,
-      "DefaultValue": {
-        "X": 0.0,
-        "Y": 0.0,
-        "Z": 0.0
-      }
-    },
-    {
-      "Id": "febfae90-13e8-4f0a-8ccf-b8825ea525f8"/*Pivot*/,
-      "DefaultValue": {
-        "X": 0.0,
-        "Y": 0.0,
-        "Z": 0.0
-      }
-    }
-  ],
+    "Inputs": [
+        {
+            "Id": "97c9849e-751c-49a9-823d-0af839fa503e" /*Stretch*/,
+            "DefaultValue": {
+                "X": 1.0,
+                "Y": 1.0,
+                "Z": 1.0
+            }
+        },
+        {
+            "Id": "9a7d34a1-ca39-48bc-b977-9a786d23f3b1" /*Scale*/,
+            "DefaultValue": 1.0
+        },
+        {
+            "Id": "e445a6da-0b66-46ae-ad2b-650e9cc50798" /*Segments*/,
+            "DefaultValue": {
+                "X": 1,
+                "Y": 1,
+                "Z": 1
+            }
+        },
+        {
+            "Id": "e641c244-9dc8-444d-8dee-c3e9b710f9db" /*Rotation*/,
+            "DefaultValue": {
+                "X": 0.0,
+                "Y": 0.0,
+                "Z": 0.0
+            }
+        },
+        {
+            "Id": "f4a78f77-8d8c-4b7b-8545-ea80947b428d" /*Center*/,
+            "DefaultValue": {
+                "X": 0.0,
+                "Y": 0.0,
+                "Z": 0.0
+            }
+        },
+        {
+            "Id": "e1adb865-42f5-46a9-a4ac-bfae00b03caa" /*UvMap*/,
+            "DefaultValue": 0
+        },
+        {
+            "Id": "febfae90-13e8-4f0a-8ccf-b8825ea525f8" /*Pivot*/,
+            "DefaultValue": {
+                "X": 0.0,
+                "Y": 0.0,
+                "Z": 0.0
+            }
+        }
+    ],
   "Children": [],
   "Connections": []
 }

--- a/Operators/Lib/mesh/generate/CubeMesh.t3ui
+++ b/Operators/Lib/mesh/generate/CubeMesh.t3ui
@@ -2,62 +2,70 @@
   "Id": "c47ab830-aae7-4f8f-b67c-9119bcbaf7df"/*CubeMesh*/,
   "Description": "Generates a procedural three-dimensional mesh which can be rendered with [DrawMesh] , [DrawMeshUnlit] and [DrawMeshHatched] among others.\n\nFor a simple and interactive tutorial on the Tooll3 rendering pipeline, see [HowToDrawThings].\n\nIt can also become the source for a particle system with [MeshVerticesToPoints] or [PointsOnMesh].\nTo import static 3D meshes from other programs refer to [LoadObj].",
   "SymbolTags": "1",
-  "InputUis": [
-    {
-      "InputId": "97c9849e-751c-49a9-823d-0af839fa503e"/*Stretch*/,
-      "Position": {
-        "X": -200.0,
-        "Y": 45.0
-      },
-      "GroupTitle": "Scaling",
-      "Description": "Scales the size X (width) Y (height) Z (depth)"
-    },
-    {
-      "InputId": "9a7d34a1-ca39-48bc-b977-9a786d23f3b1"/*Scale*/,
-      "Position": {
-        "X": -200.0,
-        "Y": 0.0
-      },
-      "Description": "Uniformly scales the mesh"
-    },
-    {
-      "InputId": "e445a6da-0b66-46ae-ad2b-650e9cc50798"/*Segments*/,
-      "Position": {
-        "X": -200.0,
-        "Y": 0.0
-      },
-      "GroupTitle": "Tesselation",
-      "Description": "Amount of segments from left to right / top to bottom / front to back."
-    },
-    {
-      "InputId": "e641c244-9dc8-444d-8dee-c3e9b710f9db"/*Rotation*/,
-      "Position": {
-        "X": -200.0,
-        "Y": 135.0
-      },
-      "Description": "Rotates the Mesh",
-      "AddPadding": "True",
-      "Scale": 0.1,
-      "Format": "{0:0.0}°"
-    },
-    {
-      "InputId": "f4a78f77-8d8c-4b7b-8545-ea80947b428d"/*Center*/,
-      "Position": {
-        "X": -200.0,
-        "Y": 90.0
-      },
-      "Description": "Transforms the position of the pivot"
-    },
-    {
-      "InputId": "febfae90-13e8-4f0a-8ccf-b8825ea525f8"/*Pivot*/,
-      "Position": {
-        "X": -200.0,
-        "Y": 45.0
-      },
-      "GroupTitle": "Position and Rotation",
-      "Description": "Offsets the position of the pivotpoint (center).\n\nThis is helpful to change the point around which the cube rotates / along which it is scaled."
-    }
-  ],
+    "InputUis": [
+        {
+            "InputId": "97c9849e-751c-49a9-823d-0af839fa503e" /*Stretch*/,
+            "Position": {
+                "X": -200.0,
+                "Y": 45.0
+            },
+            "GroupTitle": "Scaling",
+            "Description": "Scales the size X (width) Y (height) Z (depth)"
+        },
+        {
+            "InputId": "9a7d34a1-ca39-48bc-b977-9a786d23f3b1" /*Scale*/,
+            "Position": {
+                "X": -200.0,
+                "Y": 0.0
+            },
+            "Description": "Uniformly scales the mesh"
+        },
+        {
+            "InputId": "e445a6da-0b66-46ae-ad2b-650e9cc50798" /*Segments*/,
+            "Position": {
+                "X": -200.0,
+                "Y": 0.0
+            },
+            "GroupTitle": "Tesselation",
+            "Description": "Amount of segments from left to right / top to bottom / front to back."
+        },
+        {
+            "InputId": "e641c244-9dc8-444d-8dee-c3e9b710f9db" /*Rotation*/,
+            "Position": {
+                "X": -200.0,
+                "Y": 135.0
+            },
+            "Description": "Rotates the Mesh",
+            "AddPadding": "True",
+            "Scale": 0.1,
+            "Format": "{0:0.0}°"
+        },
+        {
+            "InputId": "f4a78f77-8d8c-4b7b-8545-ea80947b428d" /*Center*/,
+            "Position": {
+                "X": -200.0,
+                "Y": 90.0
+            },
+            "Description": "Transforms the position of the pivot"
+        },
+        {
+            "InputId": "e1adb865-42f5-46a9-a4ac-bfae00b03caa" /*UvMap*/,
+            "Position": {
+                "X": -200.0,
+                "Y": 90.0
+            },
+            "Description": "Transforms the position of the pivot"
+        },
+        {
+            "InputId": "febfae90-13e8-4f0a-8ccf-b8825ea525f8" /*Pivot*/,
+            "Position": {
+                "X": -200.0,
+                "Y": 45.0
+            },
+            "GroupTitle": "Position and Rotation",
+            "Description": "Offsets the position of the pivotpoint (center).\n\nThis is helpful to change the point around which the cube rotates / along which it is scaled."
+        }
+    ],
   "SymbolChildUis": [],
   "OutputUis": [
     {


### PR DESCRIPTION
[CubeMesh]'s default UV map has overlapping faces. 
I've added a int parameter to select alternative UV maps allowing to texture the cube like in the following picture:
![image](https://github.com/user-attachments/assets/aa8306a2-a1e2-41fd-87eb-597a06db2e03)
