### PR TITLE
CI System

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,11 @@
+name: "Build"
+description: "Run common build steps"
+runs:
+  using: "composite"
+  steps:
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      
+    - name: Build Release Version
+      shell: pwsh
+      run: dotnet build --configuration Release

--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -1,0 +1,22 @@
+name: "Publish"
+description: "Run common build steps"
+runs:
+  using: "composite"
+  steps:
+  - name: Install innosetup
+    uses: crazy-max/ghaction-chocolatey@v3
+    with:
+      args: install innosetup
+
+  - name: Download dotnet-sdk and VC_redist
+    shell: pwsh
+    run: |
+      New-Item -ItemType Directory -Force -Path Installer\dependencies\downloads
+      Invoke-WebRequest -Uri "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-win-x64.exe" -OutFile "Installer\dependencies\downloads\dotnet-sdk-9.0.102-win-x64.exe"
+      Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vc_redist.x64.exe" -OutFile "Installer\dependencies\downloads\VC_redist.x64.exe"
+
+  - name: Package Application
+    shell: pwsh
+    run: iscc Installer\installer.iss /DMyAppName=Tooll-v${{ github.event.release.tag_name }} /DMyAppVersion=${{ github.event.release.tag_name }}
+
+ 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Build
+        uses: ./.github/actions/build
+
+      - name: Package
+        uses: ./.github/actions/package
+
+      - name: Upload Installer
+        uses: actions/upload-artifact@v4
+
+        with:
+          path: Installer\Output\*.exe

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,15 @@
+name: Pull Requests
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Build
+        uses: ./.github/actions/build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Pull Requests
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Build
+        uses: ./.github/actions/build
+    
+      - name: Package
+        uses: ./.github/actions/package
+      
+      - name: Upload Installer
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          files: Installer/Output/*.exe

--- a/Installer/installer.iss
+++ b/Installer/installer.iss
@@ -2,8 +2,10 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 
-#define MyAppVersion "3.10.6"
-#define MyAppName "Tooll-v3.10.6"
+#ifndef MyAppVersion
+  #define MyAppVersion "3.10.6"
+  #define MyAppName "Tooll-v3.10.6"
+#endif
 #define MyAppPublisher "t3"
 #define MyAppURL "https://www.tooll.io//"
 #define MyAppExeName "Editor.exe"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.0",
+    "version": "9.0.203",
     "rollForward": "latestMinor",
     "allowPrerelease": false
   }


### PR DESCRIPTION
I got curious today to see if I could add the Windows signing that we (@pixtur) talked about and I noticed there is no CI system. 
Since I have recently done this for Processing I figured it could be helpful here too.

This PR adds the following:
- Build and Package on main to create nightly builds
- Add a Build action to pull requests to check if pull requests provide a functional build at least.
- A release action that will build and package Tooll and upload the release binary to the created release.
   - This will also take the value of the tag associated with the release as the version name, to prevent the manual step of modifying the version for each release