### PR TITLE
fix typo in TriangularPrismField.cs

### DIFF
--- a/Operators/Lib/field/generate/TriangularPrismField.cs
+++ b/Operators/Lib/field/generate/TriangularPrismField.cs
@@ -25,7 +25,7 @@ internal sealed class TriangularPrismField : Instance<TriangularPrismField>
     public void GetPreShaderCode(CodeAssembleContext c, int inputIndex)
     {
         c.Globals["fTriangularPrism"] = """
-                                        float fTriangularPrism(float3 p, float2 h) {{
+                                        float fTriangularPrism(float3 p, float2 h) {
                                             float3 q = abs(p);
                                             return max(q.z-h.y,max(q.x*0.866025+p.y*0.5,-p.y)-h.x*0.5);
                                         }


### PR DESCRIPTION
I've just removed an extra { symbol in the code.