### PR TITLE
Fix: ReprojectToUV op missing aspect ratio calculation causing no output

### DIFF
--- a/Operators/Lib/render/_/ReprojectToUV.t3
+++ b/Operators/Lib/render/_/ReprojectToUV.t3
@@ -98,7 +98,7 @@
         {
           "Id": "78fb7501-74d9-4a27-8db2-596f25482c87"/*Source*/,
           "Type": "System.String",
-          "Value": "Resources\\lib\\3d\\mesh\\mesh-DrawReprojected.hlsl"
+          "Value": "Resources/lib/3d/mesh/mesh-DrawReprojected.hlsl"
         },
         {
           "Id": "9a8b500e-c3b1-4be1-8270-202ef3f90793"/*EntryPoint*/,
@@ -137,6 +137,12 @@
       "Outputs": []
     },
     {
+      "Id": "71a817a6-7eb3-424c-8eb6-6e44f49c33fc"/*GetTextureSize*/,
+      "SymbolId": "daec568f-f7b4-4d81-a401-34d62462daab",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
       "Id": "82748f9b-e601-4b57-afad-b759b188caf4"/*MultiplyInt*/,
       "SymbolId": "6a4edb6a-5ced-4356-9090-4bf770cdeb52",
       "InputValues": [
@@ -155,7 +161,7 @@
         {
           "Id": "24646f06-1509-43ce-94c6-eeb608ad97cd"/*Source*/,
           "Type": "System.String",
-          "Value": "Resources\\lib\\3d\\mesh\\mesh-DrawReprojected.hlsl"
+          "Value": "Resources/lib/3d/mesh/mesh-DrawReprojected.hlsl"
         },
         {
           "Id": "501338b3-f432-49a5-bdbd-bcf209671305"/*EntryPoint*/,
@@ -224,6 +230,12 @@
       "Outputs": []
     },
     {
+      "Id": "aca6e9f3-28af-485b-86ce-4fc0cc33a9fb"/*Vector2Components*/,
+      "SymbolId": "0946c48b-85d8-4072-8f21-11d17cc6f6cf",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
       "Id": "b70f9755-2971-47ef-a207-bc6925b7d01c"/*GetSRVProperties*/,
       "SymbolId": "bc489196-9a30-4580-af6f-dc059f226da1",
       "InputValues": [],
@@ -232,6 +244,12 @@
     {
       "Id": "b9a919e6-d1e4-4c2f-81c5-1ce813c54fcc"/*IntValue*/,
       "SymbolId": "cc07b314-4582-4c2c-84b8-bb32f59fc09b",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "beebb61d-a899-4674-b2d6-c0196365704a"/*Div*/,
+      "SymbolId": "15fb88b2-81a1-43b8-97ba-41221293bb07",
       "InputValues": [],
       "Outputs": []
     },
@@ -390,6 +408,12 @@
       "TargetSlotId": "5d73ebe6-9aa0-471a-ae6b-3f5bfd5a0f9c"
     },
     {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "04e2fd86-3dbc-4718-9f3b-361dff3e49c8",
+      "TargetParentOrChildId": "71a817a6-7eb3-424c-8eb6-6e44f49c33fc",
+      "TargetSlotId": "8b15d8e1-10c7-41e1-84db-a85e31e0c909"
+    },
+    {
       "SourceParentOrChildId": "b70f9755-2971-47ef-a207-bc6925b7d01c",
       "SourceSlotId": "431b39fd-4b62-478b-bbfa-4346102c3f61",
       "TargetParentOrChildId": "82748f9b-e601-4b57-afad-b759b188caf4",
@@ -432,6 +456,12 @@
       "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
     },
     {
+      "SourceParentOrChildId": "beebb61d-a899-4674-b2d6-c0196365704a",
+      "SourceSlotId": "866642e7-17dd-4375-9d5e-2e3747a554c2",
+      "TargetParentOrChildId": "867c48a3-7c31-4bd2-b7ee-87735eee9822",
+      "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
+    },
+    {
       "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
       "SourceSlotId": "cb1254ab-4d68-41db-a326-c5e34bb5d2f4",
       "TargetParentOrChildId": "905560db-45c8-443d-a923-405a0d65b0e8",
@@ -450,6 +480,12 @@
       "TargetSlotId": "1b0b7587-de86-4fc4-be78-a21392e8aa9b"
     },
     {
+      "SourceParentOrChildId": "71a817a6-7eb3-424c-8eb6-6e44f49c33fc",
+      "SourceSlotId": "895c3bdd-38a8-4613-a8b2-503ec9d493c8",
+      "TargetParentOrChildId": "aca6e9f3-28af-485b-86ce-4fc0cc33a9fb",
+      "TargetSlotId": "36f14238-5bb8-4521-9533-f4d1e8fb802b"
+    },
+    {
       "SourceParentOrChildId": "4483843e-0fc0-4f4d-a3b5-f6daeeb7887e",
       "SourceSlotId": "1368ab8e-d75e-429f-8ecd-0944f3ede9ab",
       "TargetParentOrChildId": "b70f9755-2971-47ef-a207-bc6925b7d01c",
@@ -460,6 +496,18 @@
       "SourceSlotId": "5e847363-142d-4da9-a5b3-3a7aa2541bed",
       "TargetParentOrChildId": "b9a919e6-d1e4-4c2f-81c5-1ce813c54fcc",
       "TargetSlotId": "4515c98e-05bc-4186-8773-4d2b31a8c323"
+    },
+    {
+      "SourceParentOrChildId": "aca6e9f3-28af-485b-86ce-4fc0cc33a9fb",
+      "SourceSlotId": "1cee5adb-8c3c-4575-bdd6-5669c04d55ce",
+      "TargetParentOrChildId": "beebb61d-a899-4674-b2d6-c0196365704a",
+      "TargetSlotId": "70460191-7573-400f-ba88-11878ecc917c"
+    },
+    {
+      "SourceParentOrChildId": "aca6e9f3-28af-485b-86ce-4fc0cc33a9fb",
+      "SourceSlotId": "305d321d-3334-476a-9fa3-4847912a4c58",
+      "TargetParentOrChildId": "beebb61d-a899-4674-b2d6-c0196365704a",
+      "TargetSlotId": "a79a2f16-7a4e-464d-8af4-3e3029ae853e"
     },
     {
       "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",

--- a/Operators/Lib/render/_/ReprojectToUV.t3ui
+++ b/Operators/Lib/render/_/ReprojectToUV.t3ui
@@ -7,8 +7,8 @@
       "InputId": "04e2fd86-3dbc-4718-9f3b-361dff3e49c8"/*Texture*/,
       "Relevancy": "Relevant",
       "Position": {
-        "X": 545.7166,
-        "Y": 4204.0938
+        "X": 1052.2343,
+        "Y": 4468.8706
       },
       "Description": "Render / Texture input",
       "AddPadding": "True"
@@ -17,16 +17,16 @@
       "InputId": "5ba52f22-0fe6-4316-a512-7577fcdff091"/*Mesh*/,
       "Relevancy": "Required",
       "Position": {
-        "X": 545.7166,
-        "Y": 4260.0938
+        "X": 1051.2126,
+        "Y": 4532.728
       },
       "Description": "Mesh input"
     },
     {
       "InputId": "6ff4c0bd-f47c-48f2-a2bc-ba13f7cff3ce"/*Resolution*/,
       "Position": {
-        "X": 554.13184,
-        "Y": 4514.247
+        "X": 1053.3485,
+        "Y": 4886.0044
       },
       "Description": "Defines the resolution of the output.\nPowers of 2 are recommended (128, 256, 512, 1024, 2048, ...)",
       "AddPadding": "True"
@@ -34,8 +34,8 @@
     {
       "InputId": "c4fff7ca-02d3-4337-b4e8-9c3074f98eb5"/*ClearColor*/,
       "Position": {
-        "X": 554.13184,
-        "Y": 4559.247
+        "X": 1053.3485,
+        "Y": 4931.0044
       },
       "Description": "defines the clear color",
       "Min": 0.0,
@@ -46,16 +46,16 @@
       "InputId": "cb1254ab-4d68-41db-a326-c5e34bb5d2f4"/*CameraReference*/,
       "Relevancy": "Required",
       "Position": {
-        "X": 545.7166,
-        "Y": 4305.0938
+        "X": 1051.5767,
+        "Y": 3975.7637
       },
       "Description": "Input for the camera reference output"
     },
     {
       "InputId": "e52b254e-e13b-4df8-81d4-35867aeb188e"/*TextureFormat*/,
       "Position": {
-        "X": 554.13184,
-        "Y": 4604.247
+        "X": 1053.3485,
+        "Y": 4976.0044
       },
       "Description": "defines the DirectX format of rendering (colordepths, channels etc.)",
       "AddPadding": "True"
@@ -63,8 +63,8 @@
     {
       "InputId": "eb4da1b0-f9c6-480d-a1a3-ac875cbf1037"/*Color*/,
       "Position": {
-        "X": 548.2994,
-        "Y": 4083.9585
+        "X": 1052.5778,
+        "Y": 4096.942
       },
       "Description": "Color that is multiplied with the generated image"
     }
@@ -73,22 +73,22 @@
     {
       "ChildId": "0f246813-7b20-47a5-ab60-fcabb4c83e15"/*PickBlendMode*/,
       "Position": {
-        "X": 2009.7332,
-        "Y": 4513.996
+        "X": 2205.2053,
+        "Y": 4761.027
       }
     },
     {
       "ChildId": "19aceab0-60d1-4354-af86-54b830811b26"/*Draw*/,
       "Position": {
-        "X": 2159.7332,
-        "Y": 4539.996
+        "X": 2344.6987,
+        "Y": 4866.4424
       }
     },
     {
       "ChildId": "366f8d4d-3e52-4998-8728-71707ade71dd"/*Rasterizer*/,
       "Position": {
-        "X": 2159.7332,
-        "Y": 4228.997
+        "X": 2343.7473,
+        "Y": 4373.2993
       }
     },
     {
@@ -99,22 +99,22 @@
         "Y": 59.905018
       },
       "Position": {
-        "X": 698.2994,
-        "Y": 4083.9585
+        "X": 1749.5616,
+        "Y": 4130.944
       }
     },
     {
       "ChildId": "4483843e-0fc0-4f4d-a3b5-f6daeeb7887e"/*GetBufferComponents*/,
       "Position": {
-        "X": 1332.7899,
-        "Y": 4282.064
+        "X": 1746.0,
+        "Y": 4624.153
       }
     },
     {
       "ChildId": "47c5968b-a9e6-4822-b6f9-a5280da91d15"/*VertexShader*/,
       "Position": {
-        "X": 1681.6351,
-        "Y": 3894.3723
+        "X": 2029.9541,
+        "Y": 4059.0217
       }
     },
     {
@@ -125,144 +125,165 @@
         "Y": 588.3471
       },
       "Position": {
-        "X": 2309.7332,
-        "Y": 4010.997
+        "X": 2520.687,
+        "Y": 3991.4377
       }
     },
     {
       "ChildId": "54f7803b-7c51-4813-9a74-690574b43436"/*RasterizerState*/,
       "Position": {
-        "X": 2009.7332,
-        "Y": 4228.997
+        "X": 2028.769,
+        "Y": 4410.524
+      }
+    },
+    {
+      "ChildId": "71a817a6-7eb3-424c-8eb6-6e44f49c33fc"/*GetTextureSize*/,
+      "Position": {
+        "X": 1472.0688,
+        "Y": 4290.338
       }
     },
     {
       "ChildId": "82748f9b-e601-4b57-afad-b759b188caf4"/*MultiplyInt*/,
       "Position": {
-        "X": 1859.7332,
-        "Y": 4552.996
+        "X": 2031.6963,
+        "Y": 4797.2036
       }
     },
     {
       "ChildId": "82c2fccc-dd33-40aa-806e-9c2b4dcf76dc"/*PixelShader*/,
       "Position": {
-        "X": 1811.3921,
-        "Y": 4393.041
+        "X": 2029.1719,
+        "Y": 4588.2505
       }
     },
     {
       "ChildId": "83f816b4-83ee-46b5-946b-98bbaa07145e"/*OutputMergerStage*/,
       "Position": {
-        "X": 2159.7332,
-        "Y": 4470.996
+        "X": 2345.2053,
+        "Y": 4761.027
       }
     },
     {
       "ChildId": "867c48a3-7c31-4bd2-b7ee-87735eee9822"/*FloatsToBuffer*/,
       "Style": "Resizable",
       "Size": {
-        "X": 135.41911,
-        "Y": 186.39783
+        "X": 140.0,
+        "Y": 175.0
       },
       "Position": {
-        "X": 1682.9324,
-        "Y": 4045.0068
+        "X": 2030.2594,
+        "Y": 4131.026
       }
     },
     {
       "ChildId": "905560db-45c8-443d-a923-405a0d65b0e8"/*GetCamTransformBuffer*/,
       "Position": {
-        "X": 1681.6351,
-        "Y": 3980.3723
+        "X": 2030.3088,
+        "Y": 3987.551
       }
     },
     {
       "ChildId": "9a8ed876-5790-476c-8cf2-df750635e007"/*SamplerState*/,
       "Position": {
-        "X": 1811.3921,
-        "Y": 4350.042
+        "X": 2031.2971,
+        "Y": 4359.213
       }
     },
     {
       "ChildId": "9abc5e98-5bfd-4a36-8e0b-973df5e3e1e9"/*SrvFromTexture2d*/,
       "Position": {
-        "X": 695.7166,
-        "Y": 4204.0938
+        "X": 1745.2738,
+        "Y": 4709.242
       }
     },
     {
       "ChildId": "9c55ce18-0e51-4416-bae6-56a037f8a1e5"/*TransformsConstBuffer*/,
       "Style": "Expanded",
       "Size": {
-        "X": 110.0,
-        "Y": 23.0
+        "X": 140.0,
+        "Y": 35.0
       },
       "Position": {
-        "X": 1681.6351,
-        "Y": 3937.3723
+        "X": 2029.5087,
+        "Y": 3922.3567
       }
     },
     {
       "ChildId": "9f65ec28-f4f4-4d9d-ad39-9fcc0bf5d251"/*_MeshBufferComponents*/,
       "Position": {
-        "X": 695.7166,
-        "Y": 4260.0938
+        "X": 1569.2665,
+        "Y": 4536.998
+      }
+    },
+    {
+      "ChildId": "aca6e9f3-28af-485b-86ce-4fc0cc33a9fb"/*Vector2Components*/,
+      "Position": {
+        "X": 1612.0688,
+        "Y": 4325.338
       }
     },
     {
       "ChildId": "b70f9755-2971-47ef-a207-bc6925b7d01c"/*GetSRVProperties*/,
       "Position": {
-        "X": 1709.7332,
-        "Y": 4552.996
+        "X": 2031.6963,
+        "Y": 4762.2036
       }
     },
     {
       "ChildId": "b9a919e6-d1e4-4c2f-81c5-1ce813c54fcc"/*IntValue*/,
       "Position": {
-        "X": 2009.7332,
-        "Y": 4552.996
+        "X": 2031.6963,
+        "Y": 4867.2036
+      }
+    },
+    {
+      "ChildId": "beebb61d-a899-4674-b2d6-c0196365704a"/*Div*/,
+      "Position": {
+        "X": 1752.0688,
+        "Y": 4325.338
       }
     },
     {
       "ChildId": "d0c5cfdb-26da-4bbe-b906-6bceb830dc5e"/*DepthStencilState*/,
       "Position": {
-        "X": 2009.7332,
-        "Y": 4470.996
+        "X": 2205.2053,
+        "Y": 4796.027
       }
     },
     {
       "ChildId": "d2434f72-5514-43ba-8e82-6087d19d9f65"/*RenderTarget*/,
       "Position": {
-        "X": 2571.5269,
-        "Y": 4157.342
+        "X": 2692.1816,
+        "Y": 3991.585
       }
     },
     {
       "ChildId": "d568cbfa-38b7-492a-93b4-c2a842cb5f4b"/*VertexShaderStage*/,
       "Position": {
-        "X": 2159.7332,
-        "Y": 4042.997
+        "X": 2341.4685,
+        "Y": 4061.474
       }
     },
     {
       "ChildId": "da5145fe-e228-4a1b-aa0a-ee61a9e311aa"/*GetBufferComponents*/,
       "Position": {
-        "X": 1332.7899,
-        "Y": 4226.064
+        "X": 1744.3322,
+        "Y": 4537.3423
       }
     },
     {
       "ChildId": "f12d3851-4c97-4284-b8dc-3a98f3fa5ca6"/*PixelShaderStage*/,
       "Position": {
-        "X": 2159.7332,
-        "Y": 4284.996
+        "X": 2344.8281,
+        "Y": 4446.0454
       }
     },
     {
       "ChildId": "f18d1ab5-2f42-4f4f-803d-599c1738dfe3"/*InputAssemblerStage*/,
       "Position": {
-        "X": 2159.7332,
-        "Y": 4010.997
+        "X": 2343.7473,
+        "Y": 3991.0168
       }
     }
   ],
@@ -270,8 +291,8 @@
     {
       "OutputId": "7d2fc5fe-0e1c-4132-9322-e08b3638bf83"/*TextureOutput*/,
       "Position": {
-        "X": 2721.5269,
-        "Y": 4157.342
+        "X": 2873.4702,
+        "Y": 3992.4868
       }
     }
   ]


### PR DESCRIPTION
Added missing aspect ratio calculation in one of the cbuffers and orgranized the node to be easily readable with the new ui styling. This should restore functionality to the same level as 3.9.3 for this operator.