### PR TITLE
Fixed BeatTimingPlayback not updating FrameCount

### DIFF
--- a/Editor/Gui/Interaction/Timing/BeatTimingPlayback.cs
+++ b/Editor/Gui/Interaction/Timing/BeatTimingPlayback.cs
@@ -1,4 +1,4 @@
-﻿using T3.Core.Animation;
+using T3.Core.Animation;
 
 namespace T3.Editor.Gui.Interaction.Timing;
 
@@ -10,6 +10,8 @@ internal sealed class BeatTimingPlayback : Playback
 {
     public override void Update(bool idleMotionEnabled = false)
     {
+        FrameCount++;
+
         var currentRuntimeInSecs = IsRenderingToFile ?   TimeInSecs : RunTimeInSecs;
 
         LastFrameDuration = (float)(currentRuntimeInSecs - _lastFrameStart);


### PR DESCRIPTION
All raymarching ops should now properly update their parameters.
The bug was caused by the check
`if (_lastUpdateFrame == Playback.FrameCount)`
in `ShaderGraphNode.Update` always failing since the FrameCount stayed at 0, and was introduced in [this commit](https://github.com/tooll3/t3/commit/791887b39d619355d4876f906ccde83a64dc3790).