### PR TITLE
fix github action name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Pull Requests
+name: Release
 on:
   release:
     types: [published]


### PR DESCRIPTION
small typo we noticed.. this fixes the labelling of actions in github: 

![screenshot](http://nikky.moe/img/firefox_okIiR271NV.png)